### PR TITLE
coverage and coveralls integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,29 @@
+[run]
+branch = True
+parallel = True
+source = pydal
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+omit = pydal/tests/*
+       pydal/contrib/*
+
+[html]
+directory = coverage_html_report

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,14 @@ deps =
     postgres2: psycopg2
     google: pyyaml
     mongo: pymongo
+    py27: python-coveralls
 commands =
-    py26: python -m unittest2.__main__ tests
-    py27,pypy: python -m unittest tests
+    py26: {envpython} -m unittest2.__main__ tests
+    py27,pypy: {envpython} -m unittest tests 
+
+[testenv:py27-google]
+commands = 
+    coverage run -m unittest tests
+    coverage combine
+    coveralls
+


### PR DESCRIPTION
sadly, I'm not proficient in tox-fu.
We need a way to let tests run (optionally, I'd guess) with coverage, that means:
- making sure coverage is installed (here python-coveralls has coverage as dependency, so we're good)
- instead of 
  
  ```
  python -m unittest tests
  ```
  
  run
  
  ```
   coverage run -m unittest tests
  ```
- run 
  
  ```
   coverage combine (not really needed, but useful if someone wants to do additional tests)
  ```
- run 
  
  ```
   coveralls
  ```
##### problems faced

tox and travis integration.... pydal uses tox as a way to keep travis.yml clean, but falls short in extensibility (probably due to my lack of tox-fu, from now on, referred as MLOTF). 
Keeping tox.ini this short means we can't have multiple commands in one-line (again, can be due to MLOTF)
Also, since tox creates a venv by default, just running "coveralls" or "coverage combine" in a after_success section on .travis.yml isn't a solution because tox changes dir after running the command. 
Ideally, on travis-ci we'd like to report coverage on any py27 run, while this PR is just a POC to make it run on py27-google. 
Again, ideally, we want a way to:
- run tests
- run tests against a specific backend
- run tests with coverage
  and have options to do that. If tox is the designed/required tool, a way must be figured out.
##### considerations

running tests on pydal with tox is beautiful (if you're not on travis-ci, it's a good thing to have it), but without a fully-configured environment (especially the backends) is quite limited.... so I guess we just need to make a choice if we want a little bit of "more" clutter in .travis.yml and keep tox just to run 2.6 and 2.7 tests "smartly" (basically it's just a matter of tests discoveries) or "require" coverage to run tests for any 2.7, because that means basically changing the "commands" to

```
commands =
    py26: {envpython} -m unittest2.__main__ tests
    py27: coverage run -m unittest tests     # <--
    pypy: {envpython} -m unittest tests 
```

or.... I don't know 'cause MLOTF . Feel free to suggest something.
