### PR TITLE
added test for sqlite using the file system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
   matrix:
     - ADAPTER=sqlite
+    - ADAPTER=sqliteFS
     - ADAPTER=mysql
     - ADAPTER=postgres
     - ADAPTER=postgresPG8000

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = {py26,py27,pypy}-{sqlite,mongo,imap,postgresPG8000}, {py26,py27}-{mysq
 [testenv]
 setenv =
     sqlite: DB=sqlite:memory
+    sqliteFS: DB=sqlite:///tmp/storage.sqlite
     mysql: DB=mysql://root:@localhost/pydal
     postgres: DB=postgres://postgres:@localhost/pydal
     postgresPG8000: DB=postgres:pg8000://postgres:@localhost/pydal


### PR DESCRIPTION
The current sqlite test uses sqlite:memory by doing that we are not able to run test against table migration for sqlite.