### PR TITLE
Fix redefine with lazy_tables, added tests

### DIFF
--- a/pydal/base.py
+++ b/pydal/base.py
@@ -793,7 +793,9 @@ class DAL(object):
             else:
                 raise SyntaxError("missing table name")
         elif hasattr(self,tablename) or tablename in self.tables:
-            if not args.get('redefine',False):
+            if args.get('redefine',False):
+                delattr(self, tablename)
+            else:
                 raise SyntaxError('table already defined: %s' % tablename)
         elif tablename.startswith('_') or hasattr(self,tablename) or \
                 REGEX_PYTHON_KEYWORDS.match(tablename):
@@ -805,7 +807,7 @@ class DAL(object):
             if invalid_args:
                 raise SyntaxError('invalid table "%s" attributes: %s' \
                     % (tablename,invalid_args))
-        if self._lazy_tables and not tablename in self._LAZY_TABLES:
+        if self._lazy_tables and tablename not in self._LAZY_TABLES:
             self._LAZY_TABLES[tablename] = (tablename,fields,args)
             table = None
         else:

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -1653,6 +1653,20 @@ class TestLazy(unittest.TestCase):
         db.t0.drop()
         return
 
+class TestRedefine(unittest.TestCase):
+
+    def testRun(self):
+        db = DAL(DEFAULT_URI, check_reserved=['all'], lazy_tables=True, migrate=False)
+        db.define_table('t_a', Field('code'))
+        self.assertTrue('code' in db.t_a)
+        self.assertTrue('code' in db['t_a'])
+        db.define_table('t_a', Field('code_a'), redefine=True)
+        self.assertFalse('code' in db.t_a)
+        self.assertFalse('code' in db['t_a'])
+        self.assertTrue('code_a' in db.t_a)
+        self.assertTrue('code_a' in db['t_a'])
+        return
+
 if __name__ == '__main__':
     unittest.main()
     tearDownModule()


### PR DESCRIPTION
Fix https://github.com/web2py/pydal/issues/65
The tests added have migrate=False though. with migrate=True I think that redefining a table should trigger a table migration or so, but currently it fails.