### PR TITLE
use native drop for mongo adapter

### DIFF
--- a/pydal/adapters/google_adapters.py
+++ b/pydal/adapters/google_adapters.py
@@ -244,7 +244,7 @@ class GoogleDatastoreAdapter(NoSQLAdapter):
         elif isinstance(expression,(list,tuple)):
             return ','.join([self.represent(item,field_type) for item in expression])
         else:
-            raise NotImplemtedError
+            raise NotImplementedError
 
     def AND(self,first,second):
         first = self.expand(first)
@@ -403,7 +403,6 @@ class GoogleDatastoreAdapter(NoSQLAdapter):
                 raise SyntaxError('Set: no groupby in appengine')
             orderby = args_get('orderby', False)
             if orderby:
-                ### THIS REALLY NEEDS IMPROVEMENT !!!
                 if isinstance(orderby, (list, tuple)):
                     orderby = xorify(orderby)
                 if isinstance(orderby,Expression):
@@ -411,7 +410,6 @@ class GoogleDatastoreAdapter(NoSQLAdapter):
                 orders = orderby.split(', ')
                 tbl = tableobj
                 for order in orders:
-                    #TODO There must be a better way
                     order = str(order)
                     desc = order[:1] == '-'
                     name = order[1 if desc else 0:].split('.')[-1]

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -188,6 +188,7 @@ class MongoDBAdapter(NoSQLAdapter):
                      polymodel=None, isCapped=False):
         if isCapped:
             raise RuntimeError("Not implemented")
+        table._dbt = None
 
     def count(self, query, distinct=None, snapshot=True):
         if distinct:
@@ -248,6 +249,8 @@ class MongoDBAdapter(NoSQLAdapter):
     def drop(self, table, mode=''):
         ctable = self.connection[table._tablename]
         ctable.drop()
+        self._drop_cleanup(table)
+        return
 
     def truncate(self, table, mode, safe=None):
         if safe == None:

--- a/tests/_adapt.py
+++ b/tests/_adapt.py
@@ -8,9 +8,7 @@ IS_MONGODB = "mongodb" in DEFAULT_URI
 IS_POSTGRESQL = 'postgres' in DEFAULT_URI
 
 def drop(table, cascade=None):
-    # mongodb implements drop()
-    # although it seems it does not work properly
-    if NOSQL:
+    if NOSQL and not (IS_MONGODB):
         # GAE drop/cleanup is not implemented
         db = table._db
         db[table]._common_filter = None

--- a/tests/nosql.py
+++ b/tests/nosql.py
@@ -343,12 +343,15 @@ class TestBelongs(unittest.TestCase):
     def testRun(self):
         db = DAL(DEFAULT_URI, check_reserved=['all'])
         db.define_table('tt', Field('aa'))
-
-        self.assertEqual(isinstance(db.tt.insert(aa='1'), long), True)
+        i_id = db.tt.insert(aa='1')
+        self.assertEqual(isinstance(i_id, long), True)
         self.assertEqual(isinstance(db.tt.insert(aa='2'), long), True)
         self.assertEqual(isinstance(db.tt.insert(aa='3'), long), True)
-        self.assertEqual(db(db.tt.aa.belongs(('1', '3'))).count(),
-                         2)
+        self.assertEqual(db(db.tt.aa.belongs(('1', '3'))).count(), 2)
+        self.assertEqual(db(db.tt.aa.belongs(['1', '3'])).count(), 2)
+        self.assertEqual(db(db.tt.aa.belongs(['1', '3'])).count(), 2)
+        self.assertEqual(db(db.tt.id.belongs([i_id])).count(), 1)
+
         if not (IS_GAE or IS_MONGODB):
             self.assertEqual(db(db.tt.aa.belongs(db(db.tt.id > 2)._select(db.tt.aa))).count(), 1)
 


### PR DESCRIPTION
The method *_drop_cleanup* removes all references to the table definition at pydal level.
It is placed in BaseAdapter, to some extent it should belong to DAL though. 
Let me know if I have to move it there