### PR TITLE
Added ability to connection pool to use custom db test queries per adapter

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -85,6 +85,7 @@ class BaseAdapter(ConnectionPool):
     FALSE = 'F'
     T_SEP = ' '
     QUOTE_TEMPLATE = '"%s"'
+    test_query = 'SELECT 1;'
 
 
     types = {

--- a/pydal/adapters/db2.py
+++ b/pydal/adapters/db2.py
@@ -72,7 +72,9 @@ class DB2Adapter(BaseAdapter):
         self.db_codec = db_codec
         self._after_connection = after_connection
         self.find_or_make_work_folder()
+        self.test_query = 'SELECT 1 FROM (VALUES ( 1 ));'
         ruri = uri.split('://', 1)[1]
+
         
         def connector(cnxn=ruri,driver_args=driver_args):
             if self.driver_name == 'ibm_db_dbi':

--- a/pydal/adapters/informix.py
+++ b/pydal/adapters/informix.py
@@ -86,6 +86,7 @@ class InformixAdapter(BaseAdapter):
         self.db_codec = db_codec
         self._after_connection = after_connection
         self.find_or_make_work_folder()
+        self.test_query = 'SELECT COUNT(*) FROM systables;'
         ruri = uri.split('://',1)[1]
         m = self.REGEX_URI.match(ruri)
         if not m:

--- a/pydal/adapters/oracle.py
+++ b/pydal/adapters/oracle.py
@@ -108,6 +108,7 @@ class OracleAdapter(BaseAdapter):
         self.db_codec = db_codec
         self._after_connection = after_connection
         self.find_or_make_work_folder()
+        self.test_query = 'SELECT 1 FROM DUAL;'
         ruri = uri.split('://',1)[1]
         if not 'threaded' in driver_args:
             driver_args['threaded']=True

--- a/pydal/connection.py
+++ b/pydal/connection.py
@@ -112,7 +112,7 @@ class ConnectionPool(object):
                     self.cursor = cursor and self.connection.cursor()
                     try:
                         if self.cursor and self.check_active_connection:
-                            self.execute('SELECT 1;')
+			    self.execute(self.test_query)
                         break
                     except:
                         pass


### PR DESCRIPTION
Added ability to connection pool to use custom db test queries per adapter as SELECT 1; fails on DB2, Informix, and Oracle.

The default 'SELECT 1;' works on many databases such as: 

    MySQL
    Microsoft SQL Server 
    PostgreSQL
    SQLite
    Ingres

However some databases require a stricter adherence to the SQL standard and require both a "SELECT" and a "FROM" value in the select statements. 

These databases include

    DB2
    Informix
    Oracle
    Firebird

This pull request adds support to the connection.py file to use the test query provided by the adapter. The default (in base.py) is still 'SELECT 1;' so no action is needed to support already working databases. 

I have also added the correct test queries to the DB2, Oracle and Informix DB adapters. 

This will provide a significant performance enhancement under load of multiple users for sites using DB2, Oracle or Informix databases. 

The root cause is that the connection pool would try all connections in the pool with the test query. The test query would fail however, so the connection pool would loop until the entire pool was exhausted, then a fresh connection and pool would be setup. The query would then run without first running the test query and succeed. The only problem being that the larger the connection pool, the longer it would take to service each connection/request. 

Due to web2py's architecture, every page request generated a request from the connection pool. No query was ever run other than the test query which would fail, causing web2py to eat cycles and stop processing concurrent user requests until a new connection was established and the connection pool was repopulated.

With this change, the correct test query can be run and on success continue on quickly rather than reattempt testing more connections from the pool.

I was able to use Apache ab to test the issue and confirm the fix.   

Running 

    ab -n 1000 -c 20 http://localhost:8000

Before the fix is applied and with a connection in db.py setup to connect to DB2/Oracle etc, this command would effectively DOS the web2py application. 

After the patch, the application remains very responsive and does not time out. 
