### PR TITLE
fix broken boolean type in MSSQL2Adapter. closes web2py/pydal#62

### DIFF
--- a/pydal/adapters/mssql.py
+++ b/pydal/adapters/mssql.py
@@ -335,7 +335,7 @@ class MSSQL2Adapter(MSSQLAdapter):
     drivers = ('pyodbc',)
 
     types = {
-        'boolean': 'CHAR(1)',
+        'boolean': 'BIT',
         'string': 'NVARCHAR(%(length)s)',
         'text': 'NTEXT',
         'json': 'NTEXT',


### PR DESCRIPTION
as discussed in https://github.com/web2py/pydal/issues/62 the current implementation is broken.
The following return False.
```
db = DAL('mssql2://user:passwd@ip/db')
db.define_table('tt', Field('aa', 'boolean', default=True))
db.tt.insert(aa=True)
db().select(db.tt.aa)[0].aa == True
```