### PR TITLE
test and fix as_json when web2py serializer is not available, closes web2py/pydal#112

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2726,13 +2726,13 @@ class Rows(object):
         mode='object' is not implemented (should return a nested
         object structure)
         """
-
+        has_serializer = self.db.has_serializer('json')
         items = [record.as_json(mode=mode, default=default,
                                 serialize=False,
-                                colnames=self.colnames) for
+                                colnames=self.colnames, datetime_to_str=not(has_serializer)) for
                  record in self]
 
-        if self.db.has_serializer('json'):
+        if has_serializer:
             custom_json = self.db.serializers.custom_json if \
                 self.db.has_serializer('custom_json') else None
             return self.db.serialize('json', items,

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -1826,6 +1826,19 @@ class TestConnection(unittest.TestCase):
             db4.close()
         self.assertEqual(len(db4._adapter.POOLS[DEFAULT_URI]), 0)
 
+class TestSerializers(unittest.TestCase):
+
+    def testAsJson(self):
+        db = DAL(DEFAULT_URI, check_reserved=['all'])
+        db.define_table('tt', Field('date_field', 'datetime'))
+        db.tt.insert(date_field=datetime.datetime.now())
+        rows = db().select(db.tt.ALL)
+        j=rows.as_json()
+        import json #standard library
+        json.loads(j)
+        db.tt.drop()
+        db.close()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I'd consider to backport https://github.com/web2py/web2py/blob/master/gluon/serializers.py (or part of it) in pydal.