### PR TITLE
fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ pyDAL comes from the original web2py's DAL, with the aim of being wide-compatibl
 
 [![pip version](https://img.shields.io/pypi/v/pydal.svg?style=flat-square)](https://pypi.python.org/pypi/pydal) 
 [![Build Status](https://img.shields.io/travis/web2py/pydal/master.svg?style=flat-square)](https://travis-ci.org/web2py/pydal)
-[![Coverage Status](https://img.shields.io/coveralls/web2py/pydal.svg?style=flat-square)](https://coveralls.io/r/web2py/pydal)
+[![MS Build Status](https://ci.appveyor.com/api/projects/status/qs4aex0ki8v8ruhp/branch/master?svg=true)](https://ci.appveyor.com/project/niphlod/pydal-7r7t6)
+[![Coverage Status](https://img.shields.io/codecov/c/github/web2py/pydal.svg?style=flat-square)](https://codecov.io/github/web2py/pydal)
 [![API Docs Status](https://readthedocs.org/projects/pydal/badge/?version=latest&style=flat-square)](http://pydal.rtfd.org/)
 
 ## Installation


### PR DESCRIPTION
I know. Appveyor doesn't seem to create clean urls for orgs. I'll contact their support, but for the time being, this is it.