### PR TITLE
fix delete_uploaded_files for computed fields

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2055,6 +2055,8 @@ class Set(Serializable):
         # ## mind uploadfield==True means file is not in DB
         if upload_fields:
             fields = upload_fields.keys()
+            # Explicity add compute upload fields (ex: thumbnail)
+            fields += [f for f in table.fields if table[f].compute is not None]
         else:
             fields = table.fields
         fields = [f for f in fields if table[f].type == 'upload'
@@ -2068,7 +2070,8 @@ class Set(Serializable):
                 oldname = record.get(fieldname, None)
                 if not oldname:
                     continue
-                if upload_fields and oldname == upload_fields[fieldname]:
+                if (upload_fields and fieldname in upload_fields and
+                    oldname == upload_fields[fieldname]):
                     continue
                 if field.custom_delete:
                     field.custom_delete(oldname)


### PR DESCRIPTION
A common thumbnail is defined as follows, The file is not deleted after update/delete. This PR fix it.
```
    Field("thumbnail", "upload", uploadfolder=os.path.join(request.folder,'uploads'),
          autodelete=True,  requires=[IS_IMAGE()],
          compute = lambda row: THUMBER(row.picture, 250, 200, name='thumb'))
```