### PR TITLE
Fix contains for mongo db

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1210,7 +1210,7 @@ class Expression(object):
 
     def contains(self, value, all=False, case_sensitive=False):
         """
-        For MongoDB and GAE contains is always case sensitive
+        For GAE contains() is always case sensitive
         """
         db = self.db
         if isinstance(value,(list, tuple)):

--- a/tests/nosql.py
+++ b/tests/nosql.py
@@ -425,7 +425,6 @@ class TestBelongs(unittest.TestCase):
 
 @unittest.skipIf(IS_GAE or IS_IMAP, "Contains not supported on GAE Datastore. TODO: IMAP tests")
 class TestContains(unittest.TestCase):
-    @unittest.skipIf(IS_MONGODB, "TODO: MongoDB Contains error")
     def testRun(self):
         db = DAL(DEFAULT_URI, check_reserved=['all'])
         db.define_table('tt', Field('aa', 'list:string'), Field('bb','string'))
@@ -439,6 +438,18 @@ class TestContains(unittest.TestCase):
         self.assertEqual(db(db.tt.bb.contains('b')).count(), 1)
         self.assertEqual(db(db.tt.bb.contains('d')).count(), 0)
         self.assertEqual(db(db.tt.aa.contains(db.tt.bb)).count(), 1)
+
+        #case-sensitivity tests, if 1 it isn't
+        is_case_insensitive = db(db.tt.bb.contains('AAA', case_sensitive=True)).count()
+        if is_case_insensitive:
+            self.assertEqual(db(db.tt.aa.contains('AAA')).count(), 2)
+            self.assertEqual(db(db.tt.bb.contains('A')).count(), 3)
+        else:
+            self.assertEqual(db(db.tt.aa.contains('AAA', case_sensitive=True)).count(), 0)
+            self.assertEqual(db(db.tt.bb.contains('A', case_sensitive=True)).count(), 0)
+            self.assertEqual(db(db.tt.aa.contains('AAA', case_sensitive=False)).count(), 2)
+            self.assertEqual(db(db.tt.bb.contains('A', case_sensitive=False)).count(), 3)
+
         drop(db.tt)
         db.close()
 


### PR DESCRIPTION
For MongoDB Driver, restructure contains(), like(), ilike(), startswith() and endswith() to use consistent regex construction and to allow test cases to pass.  This sits on top of https://github.com/web2py/pydal/pull/180, who's changes were necessary for this change to pass its test cases.  This can make this change look way busier than it is.