### PR TITLE
quickfix for unicode and postgresql on py2. Fails miserably on py3.

### DIFF
--- a/pydal/adapters/postgres.py
+++ b/pydal/adapters/postgres.py
@@ -3,6 +3,7 @@ import re
 
 from .._globals import IDENTITY
 from ..drivers import psycopg2_adapt
+from .._compat import PY2
 from ..helpers.methods import varquote_aux
 from .base import BaseAdapter
 from ..objects import Expression
@@ -49,8 +50,9 @@ class PostgreSQLAdapter(BaseAdapter):
     def adapt(self, obj):
         if self.driver_name == 'psycopg2':
             rv = psycopg2_adapt(obj).getquoted()
-            if isinstance(rv, bytes):
-                return rv.decode("utf8")
+            if not PY2:
+                if isinstance(rv, bytes):
+                    return rv.decode('utf-8')
             return rv
         elif self.driver_name == 'pg8000':
             return "'%s'" % obj.replace("%", "%%").replace("'", "''")


### PR DESCRIPTION
Needs further reconsideration but can be included for a new tagged
release to be released with web2py, that can't suffer for py3 errors.
fixes momentarily for py2 https://github.com/web2py/pydal/issues/136 . 
for python3 we should reconsider using psycopg_adapt interely, but that's a post for another story