### PR TITLE
fix and added not-null/unique support for big-reference data type

### DIFF
--- a/pydal/adapters/mssql.py
+++ b/pydal/adapters/mssql.py
@@ -41,7 +41,7 @@ class MSSQLAdapter(BaseAdapter):
         'geometry': 'geometry',
         'geography': 'geography',
         'big-id': 'BIGINT IDENTITY PRIMARY KEY',
-        'big-reference': 'BIGINT NULL, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT %(null)s %(unique)s, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference FK': ', CONSTRAINT FK_%(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference TFK': ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
         }
@@ -255,7 +255,7 @@ class MSSQL3Adapter(MSSQLAdapter):
         'geometry': 'geometry',
         'geography': 'geography',
         'big-id': 'BIGINT IDENTITY PRIMARY KEY',
-        'big-reference': 'BIGINT NULL, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT %(null)s %(unique)s, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference FK': ', CONSTRAINT FK_%(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference TFK': ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
     }
@@ -311,7 +311,7 @@ class MSSQL4Adapter(MSSQLAdapter):
         'geometry': 'geometry',
         'geography': 'geography',
         'big-id': 'BIGINT IDENTITY PRIMARY KEY',
-        'big-reference': 'BIGINT NULL, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT %(null)s %(unique)s, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference FK': ', CONSTRAINT FK_%(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference TFK': ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
     }
@@ -366,7 +366,7 @@ class MSSQL2Adapter(MSSQLAdapter):
         'geometry': 'geometry',
         'geography': 'geography',
         'big-id': 'BIGINT IDENTITY PRIMARY KEY',
-        'big-reference': 'BIGINT, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT %(null)s %(unique)s, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference FK': ', CONSTRAINT FK_%(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference TFK': ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
     }
@@ -426,7 +426,7 @@ class MSSQLNAdapter(MSSQLAdapter):
         'geometry': 'geometry',
         'geography': 'geography',
         'big-id': 'BIGINT IDENTITY PRIMARY KEY',
-        'big-reference': 'BIGINT, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT %(null)s %(unique)s, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference FK': ', CONSTRAINT FK_%(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference TFK': ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
     }
@@ -487,7 +487,7 @@ class MSSQL3NAdapter(MSSQLNAdapter):
         'geometry': 'geometry',
         'geography': 'geography',
         'big-id': 'BIGINT IDENTITY PRIMARY KEY',
-        'big-reference': 'BIGINT NULL, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT %(null)s %(unique)s, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference FK': ', CONSTRAINT FK_%(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference TFK': ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
     }
@@ -547,7 +547,7 @@ class MSSQL4NAdapter(MSSQLNAdapter):
         'geometry': 'geometry',
         'geography': 'geography',
         'big-id': 'BIGINT IDENTITY PRIMARY KEY',
-        'big-reference': 'BIGINT NULL, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT %(null)s %(unique)s, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference FK': ', CONSTRAINT FK_%(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference TFK': ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
     }

--- a/pydal/adapters/mysql.py
+++ b/pydal/adapters/mysql.py
@@ -33,7 +33,7 @@ class MySQLAdapter(BaseAdapter):
         'list:string': 'LONGTEXT',
         'list:reference': 'LONGTEXT',
         'big-id': 'BIGINT AUTO_INCREMENT NOT NULL',
-        'big-reference': 'BIGINT, INDEX %(index_name)s (%(field_name)s), FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT %(null)s %(unique)s, INDEX %(index_name)s (%(field_name)s), FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference FK': ', CONSTRAINT  `FK_%(constraint_name)s` FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         }
 

--- a/pydal/adapters/postgres.py
+++ b/pydal/adapters/postgres.py
@@ -39,7 +39,7 @@ class PostgreSQLAdapter(BaseAdapter):
         'geometry': 'GEOMETRY',
         'geography': 'GEOGRAPHY',
         'big-id': 'BIGSERIAL PRIMARY KEY',
-        'big-reference': 'BIGINT REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s %(null)s %(unique)s',
         'reference FK': ', CONSTRAINT  "FK_%(constraint_name)s" FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference TFK': ' CONSTRAINT  "FK_%(foreign_table)s_PK" FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
     }
@@ -360,7 +360,7 @@ class NewPostgreSQLAdapter(PostgreSQLAdapter):
         'geometry': 'GEOMETRY',
         'geography': 'GEOGRAPHY',
         'big-id': 'BIGSERIAL PRIMARY KEY',
-        'big-reference': 'BIGINT REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+        'big-reference': 'BIGINT REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s %(null)s %(unique)s',
         'reference FK': ', CONSTRAINT  "FK_%(constraint_name)s" FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
         'reference TFK': ' CONSTRAINT  "FK_%(foreign_table)s_PK" FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
     }

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,50 +6,53 @@ class TestReferenceNOTNULL(unittest.TestCase):
 #1:N not null
 
     def testRun(self):
-        db = DAL(DEFAULT_URI, check_reserved=['all'])
-        db.define_table('tt', Field('vv'))
-        db.define_table('ttt', Field('vv'), Field('tt_id', 'reference tt', notnull=True))
-        self.assertRaises(Exception, db.ttt.insert, vv='pydal')
-        # The following is mandatory for backends as PG to close the aborted transaction
-        db.commit()
-        drop(db.ttt)
-        drop(db.tt)
-        db.close()
-        
+        for ref, bigint in [('reference', False), ('big-reference', True)]:
+            db = DAL(DEFAULT_URI, check_reserved=['all'], bigint_id=bigint)
+            db.define_table('tt', Field('vv'))
+            db.define_table('ttt', Field('vv'), Field('tt_id', '%s tt' % ref, notnull=True))
+            self.assertRaises(Exception, db.ttt.insert, vv='pydal')
+            # The following is mandatory for backends as PG to close the aborted transaction
+            db.commit()
+            drop(db.ttt)
+            drop(db.tt)
+            db.close()
+
 class TestReferenceUNIQUE(unittest.TestCase):
 # 1:1 relation
 
     def testRun(self):
-        db = DAL(DEFAULT_URI, check_reserved=['all'])
-        db.define_table('tt', Field('vv'))
-        db.define_table('ttt', Field('vv'), Field('tt_id', 'reference tt', unique=True))
-        id_i = db.tt.insert(vv='pydal')
-        # Null tt_id
-        db.ttt.insert(vv='pydal')
-        # first insert is OK
-        db.ttt.insert(tt_id=id_i)
-        self.assertRaises(Exception, db.ttt.insert, tt_id=id_i)
-        # The following is mandatory for backends as PG to close the aborted transaction
-        db.commit()
-        drop(db.ttt)
-        drop(db.tt)
-        db.close()
-        
+        for ref, bigint in [('reference', False), ('big-reference', True)]:
+            db = DAL(DEFAULT_URI, check_reserved=['all'], bigint_id=bigint)
+            db.define_table('tt', Field('vv'))
+            db.define_table('ttt', Field('vv'), Field('tt_id', '%s tt' % ref, unique=True))
+            id_i = db.tt.insert(vv='pydal')
+            # Null tt_id
+            db.ttt.insert(vv='pydal')
+            # first insert is OK
+            db.ttt.insert(tt_id=id_i)
+            self.assertRaises(Exception, db.ttt.insert, tt_id=id_i)
+            # The following is mandatory for backends as PG to close the aborted transaction
+            db.commit()
+            drop(db.ttt)
+            drop(db.tt)
+            db.close()
+
 class TestReferenceUNIQUENotNull(unittest.TestCase):
 # 1:1 relation not null
 
     def testRun(self):
-        db = DAL(DEFAULT_URI, check_reserved=['all'])
-        db.define_table('tt', Field('vv'))
-        db.define_table('ttt', Field('vv'), Field('tt_id', 'reference tt', unique=True, notnull=True))
-        self.assertRaises(Exception, db.ttt.insert, vv='pydal')
-        db.commit()
-        id_i = db.tt.insert(vv='pydal')
-        # first insert is OK
-        db.ttt.insert(tt_id=id_i)
-        self.assertRaises(Exception, db.ttt.insert, tt_id=id_i)
-        # The following is mandatory for backends as PG to close the aborted transaction
-        db.commit()
-        drop(db.ttt)
-        drop(db.tt)
-        db.close()
+        for ref, bigint in [('reference', False), ('big-reference', True)]:
+            db = DAL(DEFAULT_URI, check_reserved=['all'], bigint_id=bigint)
+            db.define_table('tt', Field('vv'))
+            db.define_table('ttt', Field('vv'), Field('tt_id', '%s tt' % ref, unique=True, notnull=True))
+            self.assertRaises(Exception, db.ttt.insert, vv='pydal')
+            db.commit()
+            id_i = db.tt.insert(vv='pydal')
+            # first insert is OK
+            db.ttt.insert(tt_id=id_i)
+            self.assertRaises(Exception, db.ttt.insert, tt_id=id_i)
+            # The following is mandatory for backends as PG to close the aborted transaction
+            db.commit()
+            drop(db.ttt)
+            drop(db.tt)
+            db.close()


### PR DESCRIPTION
Odd that the data type ```big-reference``` was completely broken so far.
Mysql works only if the referenced id is defined as ```bigint```.