### PR TITLE
MongoDB fix issue 214 ascii codec can't encode

### DIFF
--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -179,8 +179,6 @@ class MongoDBAdapter(NoSQLAdapter):
                     value = newval
             elif fieldtype.startswith("reference") or fieldtype=="id":
                 value = self.object_id(value)
-            elif fieldtype == "string":
-                value = str(value)
         elif isinstance(fieldtype, Table):
             value = self.object_id(value)
         return value

--- a/tests/nosql.py
+++ b/tests/nosql.py
@@ -125,6 +125,7 @@ class TestFields(unittest.TestCase):
 
         insert_vals = [
             ('string', 'x', ''),
+            ('string', 'A\xc3\xa9 A', ''),
             ('text', 'x', ''),
             ('password', 'x', ''),
             ('upload', 'x', ''),


### PR DESCRIPTION
Fix for https://github.com/web2py/pydal/issues/214. str(value) conversion is already handled by base adapter