### PR TITLE
MongoDB add support for ondelete CASCADE and SET NULL

### DIFF
--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -173,10 +173,7 @@ class MongoDBAdapter(NoSQLAdapter):
         elif isinstance(fieldtype, basestring):
             if fieldtype.startswith('list:'):
                 if fieldtype.startswith('list:reference'):
-                    newval = []
-                    for v in value:
-                        newval.append(self.object_id(v))
-                    value = newval
+                    value = [self.object_id(v) for v in value]
             elif fieldtype.startswith("reference") or fieldtype=="id":
                 value = self.object_id(value)
             elif fieldtype == "string":
@@ -417,17 +414,17 @@ class MongoDBAdapter(NoSQLAdapter):
 
             return amount
         except Exception as e:
-            # TODO Reverse update query to verifiy that the query succeded
+            # TODO Reverse update query to verify that the query suceeded
             raise RuntimeError("uncaught exception when updating rows: %s" % e)
 
     def delete(self, tablename, query, safe=None):
-        amount = self.count(query, False)
         if not isinstance(query, Query):
-            raise RuntimeError("query type %s is not supported" % \
-                               type(query))
+            raise RuntimeError("query type %s is not supported" % type(query))
 
         (ctable, _filter) = self._expand_query(query, safe)
+        deleted = [x['_id'] for x in ctable.find(_filter)]
 
+        # find references to deleted items
         db = self.db
         table = db[tablename]
         cascade = []
@@ -438,15 +435,41 @@ class MongoDBAdapter(NoSQLAdapter):
                     cascade.append(field)
                 if field.ondelete == 'SET NULL':
                     set_null.append(field)
-        deleted = []
-        if cascade or set_null:
-            deleted = [x['_id'] for x in ctable.find(_filter)]
+        cascade_list = []
+        set_null_list = []
+        for field in table._referenced_by_list:
+            if field.type == 'list:reference '+ tablename:
+                if field.ondelete == 'CASCADE':
+                    cascade_list.append(field)
+                if field.ondelete == 'SET NULL':
+                    set_null_list.append(field)
 
+        # perform delete
         result = ctable.delete_many(_filter)
         if result.acknowledged:
             amount = result.deleted_count
+        else:
+            amount = len(deleted)
 
+        # clean up any references
         if amount and deleted:
+            def remove_from_list(field, deleted, safe):
+                for delete in deleted:
+                    modify = {field.name: delete}
+                    dtable = self._get_collection(field.tablename, safe)
+                    result = dtable.update_many(
+                        filter=modify, update={'$pull': modify})
+
+            # for cascaded items, if the reference is the only item in the list,
+            # then remove the entire record, else delete reference from the list 
+            for field in cascade_list:
+                for delete in deleted:
+                    modify = {field.name: [delete]}
+                    dtable = self._get_collection(field.tablename, safe)
+                    result = dtable.delete_many(filter=modify)
+                remove_from_list(field, deleted, safe)
+            for field in set_null_list:
+                remove_from_list(field, deleted, safe)
             for field in cascade:
                 db(field.belongs(deleted)).delete()
             for field in set_null:

--- a/tests/nosql.py
+++ b/tests/nosql.py
@@ -52,13 +52,14 @@ ALLOWED_DATATYPES = [
 
 
 def setUpModule():
-    db = DAL(DEFAULT_URI, check_reserved=['all'])
-    def clean_table(db, tablename):
-        db.define_table(tablename)
-        drop(db[tablename])
-    for tablename in ['tt', 't0', 't1', 't2', 't3', 't4']:
-        clean_table(db, tablename)
-    db.close()
+    if not IS_IMAP:
+        db = DAL(DEFAULT_URI, check_reserved=['all'])
+        def clean_table(db, tablename):
+            db.define_table(tablename)
+            drop(db[tablename])
+        for tablename in ['tt', 't0', 't1', 't2', 't3', 't4']:
+            clean_table(db, tablename)
+        db.close()
 
 def tearDownModule():
     if os.path.isfile('sql.log'):

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -771,16 +771,19 @@ class TestReference(unittest.TestCase):
             y=db.tt.insert(name='yyy', aa = x1)
             self.assertEqual(y.aa, x1.id)
 
-            self.assertEqual(db.tt.insert(name='zzz'), 3)
-            self.assertEqual(db(db.tt.name).count(), 3)
-            db(db.tt.id == x).delete()
-            expected_count = {
-                'SET NULL': 2,
-                'CASCADE': 1,
-            }
-            self.assertEqual(db(db.tt.name).count(), expected_count[ondelete])
-            if ondelete == 'SET NULL':
-                self.assertEqual(db(db.tt.name == 'yyy').select()[0].aa, None)
+            if not DEFAULT_URI.startswith('mssql'):
+                self.assertEqual(db.tt.insert(name='zzz'), 3)
+                self.assertEqual(db(db.tt.name).count(), 3)
+                db(db.tt.id == x).delete()
+                expected_count = {
+                    'SET NULL': 2,
+                    'NO ACTION': 2,
+                    'CASCADE': 1,
+                }
+                self.assertEqual(db(db.tt.name).count(), expected_count[ondelete])
+                if ondelete == 'SET NULL':
+                    self.assertEqual(db(db.tt.name == 'yyy').select()[0].aa, None)
+
             db.tt.drop()
             db.commit()
             db.close()


### PR DESCRIPTION
Resolves https://github.com/web2py/pydal/issues/73 for references.

This does nothing for list:references. Should it?