### PR TITLE
faster BasicStorage

### DIFF
--- a/pydal/helpers/classes.py
+++ b/pydal/helpers/classes.py
@@ -347,11 +347,7 @@ class BasicStorage(object):
         except:
             raise AttributeError
 
-    def __setitem__(self, key, value):
-        self.__dict__.__setitem__(key, value)
-
-    def __setattr__(self, key, value):
-        self.__dict__.__setitem__(key, value)
+    __setitem__ = object.__setattr__
 
     def __delitem__(self, key):
         self.__dict__.__delitem__(key)

--- a/tests/_adapt.py
+++ b/tests/_adapt.py
@@ -7,6 +7,7 @@ IS_GAE = "datastore" in DEFAULT_URI
 IS_MONGODB = "mongodb" in DEFAULT_URI
 IS_POSTGRESQL = 'postgres' in DEFAULT_URI
 IS_SQLITE = 'sqlite' in DEFAULT_URI
+IS_MSSQL = 'mssql' in DEFAULT_URI
 
 def drop(table, cascade=None):
     if NOSQL and not (IS_MONGODB):


### PR DESCRIPTION
According to my results, this PR slightly increases BasicStorage performance without breaking current unitests
```
import timeit
from pydal.helpers.classes import BasicStorage
bs = BasicStorage()
def bs_set():
    bs['a'] = 'pydal'  #or bs.a = 'pydal'

print timeit.timeit(bs_set, number=10000000)
```
 |Master pydal (s)| This PR (s)
----------|----------|-----------
setitem| 4.73 | 2.55
setattr | 4.73 |  1.37

