### PR TITLE
Fix: MongoDB adapter.reconnect() issues

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -1832,6 +1832,24 @@ class NoSQLAdapter(BaseAdapter):
 
         self.fake_cursor = FakeCursor()
 
+    def null_connector(self):
+        class Bunch(dict):
+            def __init__(self, **kw):
+                dict.__init__(self, kw)
+                self.__dict__ = self
+
+            def __str__(self):
+                state = ["%s=%r" % (attribute, value)
+                         for (attribute, value)
+                         in self.__dict__.items()]
+                return '\n'.join(state)
+
+        driver = Bunch()
+        driver.cursor = lambda : self.fake_cursor
+        driver.close = lambda : None
+        driver.commit = lambda : None
+        return driver
+
     def id_query(self, table):
         return table._id > 0
 

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -55,8 +55,18 @@ class MongoDBAdapter(NoSQLAdapter):
                  credential_decoder=IDENTITY, driver_args={},
                  adapter_args={}, do_connect=True, after_connection=None):
 
-        self.db = db
-        self.uri = uri
+        super(MongoDBAdapter, self).__init__(
+            db=db,
+            uri=uri,
+            pool_size=pool_size,
+            folder=folder,
+            db_codec=db_codec,
+            credential_decoder=credential_decoder,
+            driver_args=driver_args,
+            adapter_args=adapter_args,
+            do_connect=do_connect,
+            after_connection=after_connection)
+
         if do_connect: self.find_driver(adapter_args)
         import random
         from bson.objectid import ObjectId
@@ -72,11 +82,8 @@ class MongoDBAdapter(NoSQLAdapter):
         self.WriteConcern = WriteConcern
 
         self.dbengine = 'mongodb'
-        self.folder = folder
         db['_lastsql'] = ''
         self.db_codec = 'UTF-8'
-        self._after_connection = after_connection
-        self.pool_size = pool_size
         self.find_or_make_work_folder()
         #this is the minimum amount of replicates that it should wait
         # for on insert/update
@@ -93,9 +100,13 @@ class MongoDBAdapter(NoSQLAdapter):
             raise SyntaxError("Database is required!")
 
         def connector(uri=self.uri, m=m):
-            return self.driver.MongoClient(uri, w=self.safe)[m.get('database')]
-
-        self.reconnect(connector, cursor=False)
+            driver = self.driver.MongoClient(uri, w=self.safe)[m.get('database')]
+            driver.cursor = lambda : self.fake_cursor
+            driver.close = lambda : None
+            driver.commit = lambda : None
+            return driver
+        self.connector = connector
+        self.reconnect()
 
     def object_id(self, arg=None):
         """ Convert input to a valid Mongodb ObjectId instance

--- a/tests/nosql.py
+++ b/tests/nosql.py
@@ -1552,10 +1552,24 @@ class TestRecordVersioning(unittest.TestCase):
 
 
 
-@unittest.skipIf(not IS_MONGODB, 'TODO: Connections only implemented on NoSql MongoDB')
+@unittest.skipIf(IS_IMAP, "TODO: IMAP test")
 class TestConnection(unittest.TestCase):
 
     def testRun(self):
+        # check for adapter reconnect without parameters
+        db1 = DAL(DEFAULT_URI, check_reserved=['all'])
+        db1.define_table('tt', Field('aa', 'integer'))
+        self.assertEqual(isinstance(db1.tt.insert(aa=1), long), True)
+        self.assertEqual(db1(db1.tt.aa == 1).count(), 1)
+        drop(db1.tt)
+        db1._adapter.close()
+        db1._adapter.reconnect()
+        db1.define_table('tt', Field('aa', 'integer'))
+        self.assertEqual(isinstance(db1.tt.insert(aa=1), long), True)
+        self.assertEqual(db1(db1.tt.aa == 1).count(), 1)
+        drop(db1.tt)
+        db1.close()
+
         # check connection are reused with pool_size
         connections = {}
         for a in range(10):

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -372,7 +372,7 @@ class TestSelect(unittest.TestCase):
 
     def testTestQuery(self):
         db = DAL(DEFAULT_URI, check_reserved=['all'])
-        db.executesql(db._adapter.test_query)
+        db._adapter.execute_test_query()
         db.close()
 
     def testListInteger(self):


### PR DESCRIPTION
Fix for https://github.com/web2py/pydal/issues/222: adapter.reconnect() issues with MongoDBAdapter

Add TestConnection() test case to NoSql Adapters.

Add NoSQLAdapter.FakeCursor to allow slightly better emulation of Python DBAPI (PEP-249) to allow ConnectionPool.reconnect() a little easier time dealing with NoSql DBs.

Add null_connector() for NoSql adapters

Remove cursor parameter to ConnectionPool.reconnect().

Add execute_test_query() to adapters instead of using execute(adapter.test_query) to allow NoSql DBs to accessed.

Change MondoDB, IMAP, GoogleDataStore and CouchDB drivers to use NoSQLAdapter.FakeCursor.