### PR TITLE
fixes a few intricacies properly escaping LIKE statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-sudo: false
-
 cache: pip
 
 python:
@@ -55,8 +53,8 @@ before_script:
   - if [[ $ADAPTER == postgres* ]]; then psql -c 'SHOW SERVER_VERSION' -U postgres; fi
 
   # Install last sdk for app engine (update only whenever a new release is available)
-  - if [[ $ADAPTER == google ]]; then wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.20.zip -nv; fi
-  - if [[ $ADAPTER == google ]]; then unzip -q google_appengine_1.9.20.zip; fi
+  - if [[ $ADAPTER == google ]]; then wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.22.zip -nv; fi
+  - if [[ $ADAPTER == google ]]; then unzip -q google_appengine_1.9.22.zip; fi
   - if [[ $ADAPTER == google ]]; then mv -f ./google_appengine/google ./google; fi
 
 

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -754,13 +754,13 @@ class MongoDBAdapter(NoSQLAdapter):
                 regex['$options'] = 'i'
             return regex
 
-    def LIKE(self, first, second, case_sensitive=True):
+    def LIKE(self, first, second, case_sensitive=True, escape=None):
         regex = self._build_like_regex(
             second, case_sensitive=case_sensitive, like_wildcards=True)
         return { self.expand(first): regex }
 
-    def ILIKE(self, first, second):
-        return self.LIKE(first, second, case_sensitive=False)
+    def ILIKE(self, first, second, escape=None):
+        return self.LIKE(first, second, case_sensitive=False, escape=escape)
 
     def STARTSWITH(self, first, second):
         regex = self._build_like_regex(second, starts_with=True)

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1177,13 +1177,13 @@ class Expression(object):
         db = self.db
         return Query(db, db._adapter.GE, self, value)
 
-    def like(self, value, case_sensitive=True):
+    def like(self, value, case_sensitive=True, escape=None):
         db = self.db
         op = case_sensitive and db._adapter.LIKE or db._adapter.ILIKE
-        return Query(db, op, self, value)
+        return Query(db, op, self, value, escape=escape)
 
-    def ilike(self, value):
-        return self.like(value, case_sensitive=False)
+    def ilike(self, value, escape=None):
+        return self.like(value, case_sensitive=False, escape=escape)
 
     def regexp(self, value):
         db = self.db


### PR DESCRIPTION
specifically, we used like with startswith and endswith, and contains,
improperly. We need correct (and "automagic") escaping when dealing with
those "pythonic" methods, else subtle bugs creep in.
As always, "like()" and "ilike()" maps to the exact statement in the
backend,with the usual behaviour.
like() and ilike() got also a new "escape" parameter in order to pass
whatever escaping character the user feel right. By default, the escape
character is `\`, and the term passed to the like is escaped with it.

well, it's been fun. 1st absolute time that a feature gets backported
from mssql to all t-sql backends. As usual, NoSQL is out of my reach,
and left as an exercise to the ones more well-versed into the matter.