### PR TITLE
re-enable dockerized builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: false
+
 cache: pip
 
 python:


### PR DESCRIPTION
according to docs by default builds should go in dockerized env but it
seems it's not active yet. sudo:false reactivates the dockerized
environment