### PR TITLE
FIX: with_alias() not using parse_value()

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -1686,9 +1686,8 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
             else:
                 if not '_extra' in new_row:
                     new_row['_extra'] = Row()
-                new_row['_extra'][colname] = \
-                    self.parse_value(value,
-                                     fields[j].type,blob_decode)
+                value = self.parse_value(value, fields[j].type,blob_decode)
+                new_row['_extra'][colname] = value
                 new_column_name = \
                     REGEX_SELECT_AS_PARSER.search(colname)
                 if not new_column_name is None:

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -142,6 +142,14 @@ class TestFields(unittest.TestCase):
         self.assertEqual(db.tt.insert(aa=3), 1)
         self.assertEqual(db().select(db.tt.aa)[0].aa, 3)
         db.tt.drop()
+
+        db.define_table('tt', Field('aa', 'string'))
+        ucs = 'A\xc3\xa9 A'
+        self.assertEqual(db.tt.insert(aa=ucs), 1)
+        self.assertEqual(db().select(db.tt.aa)[0].aa, ucs)
+        self.assertEqual(db().select(db.tt.aa.with_alias('zz'))[0].zz, ucs)
+        db.tt.drop()
+
         db.define_table('tt', Field('aa', 'double', default=1))
         self.assertEqual(db.tt.insert(aa=3.1), 1)
         self.assertEqual(db().select(db.tt.aa)[0].aa, 3.1)


### PR DESCRIPTION
with_alias() not using parse_value() results in different results for the value in _extra and the value using the alias (AS).  Test case shows the failure when accessing the result using the alias.

This is blocking implementation of with_alias() for MongoDB, as it won't pass the test cases.