### PR TITLE
added __getattr__ in Row, fix web2py/pydal#229, close web2py/pydal#246

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -83,6 +83,12 @@ class Row(BasicStorage):
 
     __call__ = __getitem__
 
+    def __getattr__(self, k):
+        try:
+            return self.__getitem__(k)
+        except KeyError:
+            raise AttributeError
+
     def __copy__(self):
         return Row(self)
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -1965,6 +1965,14 @@ class TestLazy(unittest.TestCase):
         db.tt.drop()
         db.close()
 
+    def testRowExtra(self):
+        db=DAL(DEFAULT_URI, lazy_tables=True)
+        tt = db.define_table('tt',  Field('value', 'integer'))
+        db.tt.insert(value=1)
+        row = db(db.tt).select('value').first()
+        self.assertEqual(row.value, 1)
+        db.tt.drop()
+        db.close()
 
 class TestRedefine(unittest.TestCase):
 


### PR DESCRIPTION
The overall performance is still the same because __getattr__ is called as a fallback of __getattribute__