### PR TITLE
MongoDB: Improvements for LIKE() and CONTAINS()

### DIFF
--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -1297,9 +1297,8 @@ class MongoDBAdapter(NoSQLAdapter):
         """
         if (isinstance(first, Field) and
                 first.type in ['integer', 'bigint', 'float', 'double']):
-            options = 'i' if case_sensitive else '' 
-            return {'$where': "RegExp('%s','%s').test(this.%s + '')"
-                % (self.expand(second, 'string'), options, first.name)}
+            return {'$where': "RegExp('%s').test(this.%s + '')"
+                % (self.expand(second, 'string'), first.name)}
 
         expanded_first = self.expand(first)
         regex_second = {'$regex': self.expand(second, 'string')}

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -1295,6 +1295,12 @@ class MongoDBAdapter(NoSQLAdapter):
             matching strings in queries. MongoDB uses Perl compatible
             regular expressions (i.e. 'PCRE') version 8.36 with UTF-8 support.
         """
+        if (isinstance(first, Field) and
+                first.type in ['integer', 'bigint', 'float', 'double']):
+            options = 'i' if case_sensitive else '' 
+            return {'$where': "RegExp('%s','%s').test(this.%s + '')"
+                % (self.expand(second, 'string'), options, first.name)}
+
         expanded_first = self.expand(first)
         regex_second = {'$regex': self.expand(second, 'string')}
         if not case_sensitive:

--- a/tests/nosql.py
+++ b/tests/nosql.py
@@ -833,14 +833,20 @@ class TestLike(unittest.TestCase):
             self.assertEqual(db(db.tt.aa.upper().regexp('COUNT') |
                                 (db.tt.aa.lower()=='xpercent')).count(), 3)
 
-    @unittest.skipIf(IS_MONGODB, "Mongodb: Like integer not implemented")
     def testLikeInteger(self):
         db = self.db
         db.tt.drop()
         db.define_table('tt', Field('aa', 'integer'))
         self.assertEqual(isinstance(db.tt.insert(aa=1111111111), long), True)
-        self.assertEqual(db(db.tt.aa.like('1%')).count(), 1)
+        self.assertEqual(isinstance(db.tt.insert(aa=1234567), long), True)
+        self.assertEqual(db(db.tt.aa.like('1%')).count(), 2)
+        self.assertEqual(db(db.tt.aa.like('1_3%')).count(), 1)
         self.assertEqual(db(db.tt.aa.like('2%')).count(), 0)
+        self.assertEqual(db(db.tt.aa.like('_2%')).count(), 1)
+        self.assertEqual(db(db.tt.aa.like('12%')).count(), 1)
+        self.assertEqual(db(db.tt.aa.like('012%')).count(), 0)
+        self.assertEqual(db(db.tt.aa.like('%45%')).count(), 1)
+        self.assertEqual(db(db.tt.aa.like('%54%')).count(), 0)
 
 
 @unittest.skipIf(IS_IMAP, "TODO: IMAP test")


### PR DESCRIPTION
Implement https://github.com/web2py/pydal/issues/235 - Escaping like for ANSI T-SQL patterns.

Changed LIKE(), CONTAINS() and their ilk to use the new REGEXP(), which uses the pipeline, so allows expressions.

Implement LIKE() for integers.

Enabled and added more test cases for above.