### PR TITLE
Allow usage of custom classes for Row (only subclasses)

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -1644,7 +1644,9 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
         """
         Return a parsed row
         """
-        new_row = Row(dict((tablename, Row()) for tablename in fields_virtual.keys()))
+        new_row = self.db.row_class(
+            dict((tablename, self.db.row_class())
+                 for tablename in fields_virtual.keys()))
         for (j, colname) in enumerate(colnames):
             value = row[j]
             tmp = tmps[j]
@@ -1653,7 +1655,7 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
                 (tablename, fieldname, table, field, ft) = tmp
                 colset = new_row.get(tablename, None)
                 if colset is None:
-                    colset = new_row[tablename] = Row()
+                    colset = new_row[tablename] = self.db.row_class()
 
                 value = self.parse_value(value, ft, blob_decode)
                 if field.filter_out:
@@ -1686,7 +1688,7 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
                             colset[referee_link] = LazySet(rfield, id)
             else:
                 if '_extra' not in new_row:
-                    new_row['_extra'] = Row()
+                    new_row['_extra'] = self.db.row_class()
                 value = self.parse_value(value, fields[j].type, blob_decode)
                 new_row['_extra'][colname] = value
                 new_column_name = self._regex_select_as_parser(colname)

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -1644,8 +1644,8 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
         """
         Return a parsed row
         """
-        new_row = self.db.row_class(
-            dict((tablename, self.db.row_class())
+        new_row = self.db.Row(
+            dict((tablename, self.db.Row())
                  for tablename in fields_virtual.keys()))
         for (j, colname) in enumerate(colnames):
             value = row[j]
@@ -1655,7 +1655,7 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
                 (tablename, fieldname, table, field, ft) = tmp
                 colset = new_row.get(tablename, None)
                 if colset is None:
-                    colset = new_row[tablename] = self.db.row_class()
+                    colset = new_row[tablename] = self.db.Row()
 
                 value = self.parse_value(value, ft, blob_decode)
                 if field.filter_out:
@@ -1688,7 +1688,7 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
                             colset[referee_link] = LazySet(rfield, id)
             else:
                 if '_extra' not in new_row:
-                    new_row['_extra'] = self.db.row_class()
+                    new_row['_extra'] = self.db.Row()
                 value = self.parse_value(value, fields[j].type, blob_decode)
                 new_row['_extra'][colname] = value
                 new_column_name = self._regex_select_as_parser(colname)

--- a/pydal/base.py
+++ b/pydal/base.py
@@ -161,7 +161,7 @@ class MetaDAL(type):
         #: intercept arguments for DAL costumisation on call
         intercepts = [
             'logger', 'representers', 'serializers', 'uuid', 'validators',
-            'validators_method']
+            'validators_method', 'row_class']
         intercepted = []
         for name in intercepts:
             val = kwargs.get(name)
@@ -255,6 +255,7 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
     representers = {}
     uuid = lambda x: str(uuid4())
     logger = logging.getLogger("pyDAL")
+    row_class = Row
 
     Table = Table
 
@@ -375,6 +376,11 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
             return
         super(DAL, self).__init__()
 
+        if not issubclass(self.row_class, Row):
+            raise RuntimeError(
+                '`row_class` must be a subclass of pydal.objects.Row'
+            )
+
         from .drivers import DRIVERS, is_jdbc
         self._drivers_available = DRIVERS
 
@@ -412,7 +418,6 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
             attempts = 5
         if uri:
             uris = isinstance(uri, (list, tuple)) and uri or [uri]
-            error = ''
             connected = False
             for k in range(attempts):
                 for uri in uris:
@@ -420,11 +425,15 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                         if is_jdbc and not uri.startswith('jdbc:'):
                             uri = 'jdbc:'+uri
                         self._dbname = REGEX_DBNAME.match(uri).group()
-                        if not self._dbname in ADAPTERS:
-                            raise SyntaxError("Error in URI '%s' or database not supported" % self._dbname)
+                        if self._dbname not in ADAPTERS:
+                            raise SyntaxError(
+                                "Error in URI '%s' or database not supported"
+                                % self._dbname
+                            )
                         # notice that driver args or {} else driver_args
                         # defaults to {} global, not correct
-                        kwargs = dict(db=self,uri=uri,
+                        kwargs = dict(db=self,
+                                      uri=uri,
                                       pool_size=pool_size,
                                       folder=folder,
                                       db_codec=db_codec,
@@ -443,25 +452,31 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                         if bigint_id:
                             if 'big-id' in types and 'reference' in types:
                                 self._adapter.types['id'] = types['big-id']
-                                self._adapter.types['reference'] = types['big-reference']
+                                self._adapter.types['reference'] = \
+                                    types['big-reference']
                         connected = True
                         break
                     except SyntaxError:
                         raise
                     except Exception:
                         tb = traceback.format_exc()
-                        self.logger.debug('DEBUG: connect attempt %i, connection error:\n%s' % (k, tb))
+                        self.logger.debug(
+                            'DEBUG: connect attempt %i, connection error:\n%s'
+                            % (k, tb)
+                        )
                 if connected:
                     break
                 else:
                     time.sleep(1)
             if not connected:
-                raise RuntimeError("Failure to connect, tried %d times:\n%s" % (attempts, tb))
+                raise RuntimeError(
+                    "Failure to connect, tried %d times:\n%s" % (attempts, tb)
+                )
         else:
-            self._adapter = BaseAdapter(db=self,pool_size=0,
-                                        uri='None',folder=folder,
-                                        db_codec=db_codec, after_connection=after_connection,
-                                        entity_quoting=entity_quoting)
+            self._adapter = BaseAdapter(
+                db=self, pool_size=0, uri='None', folder=folder,
+                db_codec=db_codec, after_connection=after_connection,
+                entity_quoting=entity_quoting)
             migrate = fake_migrate = False
         adapter = self._adapter
         self._uri_hash = table_hash or hashlib_md5(adapter.uri).hexdigest()
@@ -636,7 +651,7 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                 else:
                     i += 1
         if '/'.join(args) == 'patterns':
-            return Row({'status':200,'pattern':'list',
+            return self.row_class({'status':200,'pattern':'list',
                         'error':None,'response':patterns})
         for pattern in patterns:
             basequery, exposedfields = None, []
@@ -716,7 +731,7 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                             try:
                                 dbset=db(db[table][field].belongs(dbset._select(db[otable][selfld])))
                             except ValueError:
-                                return Row({'status':400,'pattern':pattern,
+                                return self.row_class({'status':400,'pattern':pattern,
                                             'error':'invalid path','response':None})
                         else:
                             items = [item.id for item in dbset.select(db[otable][selfld])]
@@ -732,20 +747,20 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                     if not field in db[table]: break
                     # hand-built patterns should respect .readable=False as well
                     if not db[table][field].readable:
-                        return Row({'status':418,'pattern':pattern,
+                        return self.row_class({'status':418,'pattern':pattern,
                                     'error':'I\'m a teapot','response':None})
                     try:
                         distinct = vars.get('distinct', False) == 'True'
                         offset = long(vars.get('offset',None) or 0)
                         limits = (offset,long(vars.get('limit',None) or 1000)+offset)
                     except ValueError:
-                        return Row({'status':400,'error':'invalid limits','response':None})
+                        return self.row_class({'status':400,'error':'invalid limits','response':None})
                     items =  dbset.select(db[table][field], distinct=distinct, limitby=limits)
                     if items:
-                        return Row({'status':200,'response':items,
+                        return self.row_class({'status':200,'response':items,
                                     'pattern':pattern})
                     else:
-                        return Row({'status':404,'pattern':pattern,
+                        return self.row_class({'status':404,'pattern':pattern,
                                     'error':'no record found','response':None})
                 elif tag != args[i]:
                     break
@@ -759,7 +774,7 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                     try:
                         orderby = [db[table][f] if not f.startswith('~') else ~db[table][f[1:]] for f in ofields]
                     except (KeyError, AttributeError):
-                        return Row({'status':400,'error':'invalid orderby','response':None})
+                        return self.row_class({'status':400,'error':'invalid orderby','response':None})
                     if exposedfields:
                         fields = [field for field in db[table] if str(field).split('.')[-1] in exposedfields and field.readable]
                     else:
@@ -769,17 +784,17 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                         offset = long(vars.get('offset',None) or 0)
                         limits = (offset,long(vars.get('limit',None) or 1000)+offset)
                     except ValueError:
-                        return Row({'status':400,'error':'invalid limits','response':None})
+                        return self.row_class({'status':400,'error':'invalid limits','response':None})
                     #if count > limits[1]-limits[0]:
-                    #    return Row({'status':400,'error':'too many records','response':None})
+                    #    return self.row_class({'status':400,'error':'too many records','response':None})
                     try:
                         response = dbset.select(limitby=limits,orderby=orderby,*fields)
                     except ValueError:
-                        return Row({'status':400,'pattern':pattern,
+                        return self.row_class({'status':400,'pattern':pattern,
                                     'error':'invalid path','response':None})
-                    return Row({'status':200,'response':response,
+                    return self.row_class({'status':200,'response':response,
                                 'pattern':pattern,'count':count})
-        return Row({'status':400,'error':'no matching pattern','response':None})
+        return self.row_class({'status':400,'error':'no matching pattern','response':None})
 
     def define_table(
         self,


### PR DESCRIPTION
Added `DAL.row_class` parameter to allow usage of custom classes for single rows (only as subclass of `Row`).

Note: I've changed only code that return row objects to user, internally pyDAL still using its `Row` class.