### PR TITLE
Port nosql tests to sql

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -1788,13 +1788,19 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
         return query
 
     def CASE(self,query,t,f):
+        return Expression(self.db, self.EXPAND_CASE, query, (t, f))
+
+    def EXPAND_CASE(self, query, true_false):
         def represent(x):
             types = {type(True):'boolean',type(0):'integer',type(1.0):'double'}
             if x is None: return 'NULL'
             elif isinstance(x,Expression): return str(x)
             else: return self.represent(x,types.get(type(x),'string'))
-        return Expression(self.db,'CASE WHEN %s THEN %s ELSE %s END' % \
-                              (self.expand(query),represent(t),represent(f)))
+
+        return 'CASE WHEN %s THEN %s ELSE %s END' % (
+            self.expand(query), 
+            represent(true_false[0]),
+            represent(true_false[1]))
 
     def sqlsafe_table(self, tablename, ot=None):
         if ot is not None:

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -1225,9 +1225,6 @@ class MongoDBAdapter(NoSQLAdapter):
     def EPOCH(self, first):
         return {"$divide": [{"$subtract": [self.expand(first), self.epoch]}, 1000]}
 
-    def CASE(self, query, true, false):
-        return Expression(self.db, self.EXPAND_CASE, query, (true, false))
-
     @needs_mongodb_aggregation_pipeline
     def EXPAND_CASE(self, query, true_false):
         return {"$cond": [self.expand(query),

--- a/tests/_adapt.py
+++ b/tests/_adapt.py
@@ -8,6 +8,7 @@ IS_MONGODB = "mongodb" in DEFAULT_URI
 IS_POSTGRESQL = 'postgres' in DEFAULT_URI
 IS_SQLITE = 'sqlite' in DEFAULT_URI
 IS_MSSQL = 'mssql' in DEFAULT_URI
+IS_MYSQL = 'mysql' in DEFAULT_URI
 
 def drop(table, cascade=None):
     if NOSQL and not (IS_MONGODB):

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -849,15 +849,15 @@ class TestExpressions(unittest.TestCase):
         self.assertEqual(result[exp], 15)
 
         # test case()
-        #condition = db.tt.aa > 2
-        #case = condition.case(db.tt.aa + 2, db.tt.aa - 2)
-        #my_case = case.with_alias('my_case')
-        #result = db().select(my_case)
-        #self.assertEqual(len(result), 3)
-        #self.assertEqual(result[0][my_case], -1)
-        #self.assertEqual(result[0]['my_case'], -1)
-        #self.assertEqual(result[1]['my_case'], -22)
-        #self.assertEqual(result[2]['my_case'], 5)
+        condition = db.tt.aa > 2
+        case = condition.case(db.tt.aa + 2, db.tt.aa - 2)
+        my_case = case.with_alias('my_case')
+        result = db().select(my_case)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0][my_case], -1)
+        self.assertEqual(result[0]['my_case'], -1)
+        self.assertEqual(result[1]['my_case'], -22)
+        self.assertEqual(result[2]['my_case'], 5)
 
         # test expression based delete
         self.assertEqual(db(db.tt.aa + 1 >= 4).count(), 1)


### PR DESCRIPTION
Several tests were recently added to nosql.py to support new MongoDB driver
features.  This PR ports those changes back to sql.py to hopefully ease the eventual
merge of nosql.py and sql.py in support of https://github.com/web2py/pydal/issues/25.

PR also fixes a problem with CASE() when used in select with no other fields present.