### PR TITLE
Inject virtual fields in order on Rows

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -576,10 +576,13 @@ class Table(Serializable, BasicStorage):
                 raise SyntaxError(
                     'value must be a dictionary: %s' % value)
             self.__dict__[str(key)] = value
-            if isinstance(value, FieldVirtual):
-                self._virtual_fields.append(value)
-            elif isinstance(value, FieldMethod):
-                self._virtual_methods.append(value)
+            if isinstance(value, (FieldVirtual, FieldMethod)):
+                if value.name == 'unknown':
+                    value.name = str(key)
+                if isinstance(value, FieldVirtual):
+                    self._virtual_fields.append(value)
+                else:
+                    self._virtual_methods.append(value)
 
     def __setattr__(self, key, value):
         if key[:1] != '_' and key in self:


### PR DESCRIPTION
Actually virtual fields are injected with a random order caused by an `iteritems()` call on the `Table` object, is not possible to access virtual fields trough other virtual fields (unless you're lucky enough to have the right order).

Since there's no an optimal and simple way to parse dependencies between virtual fields, is allowed the access between them using the definition order by the user.