### PR TITLE
Add COLLATE to DAL

### DIFF
--- a/pydal/adapters/mssql.py
+++ b/pydal/adapters/mssql.py
@@ -214,6 +214,9 @@ class MSSQLAdapter(BaseAdapter):
         return "(LOWER(%s) LIKE %s ESCAPE '%s')" % (self.expand(first),
                 second, escape)
 
+    def COLLATE(self, first, collation):
+        return "%s COLLATE %s" % (self.expand(first), collation)
+
     def STARTSWITH(self, first, second):
         return "(%s LIKE %s ESCAPE '\\')" % (self.expand(first),
                 self.expand(self.like_escaper_default(second)+'%', 'string'))

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1093,6 +1093,10 @@ class Expression(object):
     def coalesce_zero(self):
         db = self.db
         return Expression(db, db._adapter.COALESCE_ZERO, self, None, self.type)
+        
+    def collate(self, collation):
+        db = self.db
+        return Expression(db, db._adapter.COLLATE, self, collation, self.type)
 
     def seconds(self):
         db = self.db


### PR DESCRIPTION
Allows for accent-insensitive DAL queries like:
db.person.firstname.collate('Latin1_General_CI_AI').ilike('Joao')

Only an MSSQL implementation, but the same should work on MySQL, and Postgres will just require quotation marks.
