### PR TITLE
Update to SPATIALLIBS

### DIFF
--- a/pydal/adapters/sqlite.py
+++ b/pydal/adapters/sqlite.py
@@ -125,7 +125,7 @@ class SQLiteAdapter(BaseAdapter):
 
 
 SPATIALLIBS = {
-    'Windows':'libspatialite',
+    'Windows':'mod_spatialite.dll',
     'Linux':'libspatialite.so',
     'Darwin':'libspatialite.dylib'
     }


### PR DESCRIPTION
The most recent version of the spatialite DLL is named mod_spatialite.dll - the value of SPATIALLIBS should be modified accordingly.

This proposed edit addresses an old issue posted by Anthony (although his proposed edit mentioned another outdated version of the spatialite DLL): https://github.com/web2py/web2py/issues/1062