### PR TITLE
MongoDB: Add unique and notnull support for fields during insert

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,8 +4,8 @@ if NOSQL:
     from .nosql import *
 else:
     from .sql import *
-    from .base import *
 
 from .validation import *
 from .caching import TestCache
 from .smart_query import *
+from .base import *


### PR DESCRIPTION
This change also applies more test cases which are not applied to NoSQL, for the eventual merge of testcases - #25.