### PR TITLE
fix upload fileds with uploadfs/pyfilesystem.  Added test.

### DIFF
--- a/tests/sql.py
+++ b/tests/sql.py
@@ -149,6 +149,69 @@ class TestFields(unittest.TestCase):
             else:
                 isinstance(f.formatter(datetime.datetime.now()), str)
 
+    def testUploadField(self):
+        import tempfile
+
+        stream = tempfile.NamedTemporaryFile()
+        content = b"this is the stream content"
+        stream.write(content)
+
+        # rewind before inserting
+        stream.seek(0)
+        
+        
+        db = DAL(DEFAULT_URI, check_reserved=['all'])
+        db.define_table('tt', Field('fileobj', 'upload',
+                                    uploadfolder=tempfile.gettempdir(),
+                                    autodelete=True))
+
+        f_id = db.tt.insert(fileobj=stream)
+
+        row = db.tt[f_id]
+        (retr_name, retr_stream) = db.tt.fileobj.retrieve(row.fileobj)
+
+        # name should be the same
+        self.assertEqual(retr_name, os.path.basename(stream.name))
+        # content should be the same
+        retr_content = retr_stream.read()
+        self.assertEqual(retr_content, content)
+
+        # delete
+        row.delete_record()
+
+        # drop
+        db.tt.drop()
+        
+        # this part is triggered only if fs (AKA pyfilesystem) module is installed
+        try:
+            from fs.memoryfs import MemoryFS
+
+            # rewind before inserting
+            stream.seek(0)
+            db.define_table('tt', Field('fileobj', 'upload',
+                                        uploadfs=MemoryFS(),
+                                        autodelete=True))
+
+            f_id = db.tt.insert(fileobj=stream)
+
+            row = db.tt[f_id]
+            (retr_name, retr_stream) = db.tt.fileobj.retrieve(row.fileobj)
+
+            # name should be the same
+            self.assertEqual(retr_name, os.path.basename(stream.name))
+            # content should be the same
+            retr_content = retr_stream.read()
+            self.assertEqual(retr_content, content)
+
+            # delete
+            row.delete_record()
+
+            # drop
+            db.tt.drop()
+
+        except ImportError:
+            pass
+
     def testRun(self):
         """Test all field types and their return values"""
         db = DAL(DEFAULT_URI, check_reserved=['all'])

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -174,6 +174,9 @@ class TestFields(unittest.TestCase):
         retr_content = retr_stream.read()
         self.assertEqual(retr_content, content)
 
+        # close streams!
+        retr_stream.close()
+
         # delete
         row.delete_record()
 
@@ -200,6 +203,10 @@ class TestFields(unittest.TestCase):
             # content should be the same
             retr_content = retr_stream.read()
             self.assertEqual(retr_content, content)
+
+            # close streams
+            retr_stream.close()
+            stream.close()
 
             # delete
             row.delete_record()

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -155,7 +155,6 @@ class TestFields(unittest.TestCase):
         stream = tempfile.NamedTemporaryFile()
         content = b"this is the stream content"
         stream.write(content)
-
         # rewind before inserting
         stream.seek(0)
         
@@ -164,7 +163,6 @@ class TestFields(unittest.TestCase):
         db.define_table('tt', Field('fileobj', 'upload',
                                     uploadfolder=tempfile.gettempdir(),
                                     autodelete=True))
-
         f_id = db.tt.insert(fileobj=stream)
 
         row = db.tt[f_id]


### PR DESCRIPTION
@mdipierro  @gi0baro The upload code in present pyDAL is uncovered.  I made a test to correct a bug that shows with uploadfs=pyfilesystem.  This bug affects current web2py too.