### PR TITLE
Optimizations in parsing

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -243,11 +243,12 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
                 new_column_name = self._regex_select_as_parser(colname)
                 if new_column_name is not None:
                     column_name = new_column_name.groups(0)
-                    setattr(new_row, column_name[0], value)
+                    new_row[column_name[0]] = value
         #: add extras if needed (eg. operations results)
         if extras:
             new_row['_extra'] = extras
         #: add virtuals
+        new_row = self.db.Row(**new_row)
         for tablename in fields_virtual.keys():
             for f, v in fields_virtual[tablename]:
                 try:
@@ -261,7 +262,7 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
                     )
                 except (AttributeError, KeyError):
                     pass  # not enough fields to define virtual field
-        return self.db.Row(**new_row)
+        return new_row
 
     def _parse_expand_colnames(self, colnames):
         """

--- a/pydal/parsers/__init__.py
+++ b/pydal/parsers/__init__.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from .._compat import with_metaclass, iteritems
 from .._gae import gae
 from ..helpers._internals import Dispatcher
@@ -82,7 +83,7 @@ class Parser(with_metaclass(MetaParser)):
         self._before_registry_ = {}
         for name, obj in iteritems(self._declared_before_):
             self._before_registry_[obj.field_type] = obj.f
-        self.registered = {}
+        self.registered = defaultdict(lambda self=self: self._default)
         for name, obj in iteritems(self._declared_parsers_):
             if obj.field_type in self._before_registry_:
                 self.registered[obj.field_type] = ParserMethodWrapper(
@@ -98,7 +99,7 @@ class Parser(with_metaclass(MetaParser)):
 
     def get_parser(self, field_type):
         key = REGEX_TYPE.match(field_type).group(0)
-        return self.registered.get(key, self._default)
+        return self.registered[key]
 
     def parse(self, value, field_type):
         return self.get_parser(field_type)(value, field_type)

--- a/pydal/parsers/base.py
+++ b/pydal/parsers/base.py
@@ -62,7 +62,7 @@ class BasicParser(Parser):
         return self.registered['integer'](value, 'bigint')
 
 
-class DateTimeParser(Parser):
+class DateParser(Parser):
     @for_type('date')
     def _date(self, value):
         if isinstance(value, datetime):
@@ -70,6 +70,8 @@ class DateTimeParser(Parser):
         (y, m, d) = map(int, str(value)[:10].strip().split('-'))
         return date(y, m, d)
 
+
+class TimeParser(Parser):
     @for_type('time')
     def _time(self, value):
         if isinstance(value, datetime):
@@ -81,6 +83,8 @@ class DateTimeParser(Parser):
             (h, mi, s) = time_items + [0]
         return time(h, mi, s)
 
+
+class DateTimeParser(Parser):
     @for_type('datetime')
     def _datetime(self, value):
         value = str(value)
@@ -88,11 +92,11 @@ class DateTimeParser(Parser):
         if '+' in timezone:
             ms, tz = timezone.split('+')
             h, m = tz.split(':')
-            dt = timedelta(seconds=3600*int(h)+60*int(m))
+            dt = timedelta(seconds=3600 * int(h) + 60 * int(m))
         elif '-' in timezone:
             ms, tz = timezone.split('-')
             h, m = tz.split(':')
-            dt = -timedelta(seconds=3600*int(h)+60*int(m))
+            dt = -timedelta(seconds=3600 * int(h) + 60 * int(m))
         else:
             ms = timezone.upper().split('Z')[0]
             dt = None
@@ -146,5 +150,8 @@ class ListsParser(BasicParser):
 
 
 @parsers.register_for(SQLAdapter)
-class Commonparser(ListsParser, DateTimeParser, DecimalParser, JSONParser):
+class Commonparser(
+    ListsParser, DateParser, TimeParser, DateTimeParser, DecimalParser,
+    JSONParser
+):
     pass

--- a/pydal/parsers/sqlite.py
+++ b/pydal/parsers/sqlite.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
 from ..adapters.sqlite import SQLite
-from .base import ListsParser, DateTimeParser, JSONParser
+from .base import ListsParser, JSONParser
 from . import parsers, for_type, before_parse
 
 
 @parsers.register_for(SQLite)
-class SQLiteParser(ListsParser, DateTimeParser, JSONParser):
+class SQLiteParser(ListsParser, JSONParser):
     @before_parse('decimal')
     def decimal_extras(self, field_type):
         return {'decimals': field_type[8:-1].split(',')[-1]}

--- a/pydal/parsers/sqlite.py
+++ b/pydal/parsers/sqlite.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
 from ..adapters.sqlite import SQLite
-from .base import ListsParser, JSONParser
+from .base import ListsParser, TimeParser, JSONParser
 from . import parsers, for_type, before_parse
 
 
 @parsers.register_for(SQLite)
-class SQLiteParser(ListsParser, JSONParser):
+class SQLiteParser(ListsParser, TimeParser, JSONParser):
     @before_parse('decimal')
     def decimal_extras(self, field_type):
         return {'decimals': field_type[8:-1].split(',')[-1]}

--- a/pydal/representers/__init__.py
+++ b/pydal/representers/__init__.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from .._compat import PY2, with_metaclass, iteritems, to_unicode
 from .._gae import gae
 from ..helpers._internals import Dispatcher
@@ -182,7 +183,7 @@ class Representer(with_metaclass(MetaRepresenter)):
         self._tbefore_registry_ = {}
         for name, obj in iteritems(self._declared_tbefore_):
             self._tbefore_registry_[obj.field_type] = obj.f
-        self.registered_t = {}
+        self.registered_t = defaultdict(lambda self=self: self._default)
         for name, obj in iteritems(self._declared_trepresenters_):
             if obj.field_type in self._tbefore_registry_:
                 self.registered_t[obj.field_type] = TReprMethodWrapper(
@@ -217,7 +218,7 @@ class Representer(with_metaclass(MetaRepresenter)):
 
     def get_representer_for_type(self, field_type):
         key = REGEX_TYPE.match(field_type).group(0)
-        return self.registered_t.get(key, self._default)
+        return self.registered_t[key]
 
     def adapt(self, value):
         if PY2:


### PR DESCRIPTION
*Select 200 records on SQLite on python 2.7.11*

Before:
```
➜  pydal git:(master) ✗ python bench.py
('max', 0.02595996856689453)
('min', 0.008541107177734375)
('avg', 0.009505524396896363)
```

After:
```
➜  next git:(master) ✗ python bench.py
('max', 0.021370887756347656)
('min', 0.005117893218994141)
('avg', 0.0059148907661437985)
```