### PR TITLE
Enabling entity quoting as default behavior

### DIFF
--- a/pydal/adapters/__init__.py
+++ b/pydal/adapters/__init__.py
@@ -33,8 +33,7 @@ class AdapterMeta(type):
             'uploads_in_blob', cls.uploads_in_blob)
         cls.uploads_in_blob = uploads_in_blob
 
-        ## TODO: avoid entity quoting disable
-        entity_quoting = kwargs.get('entity_quoting', False)
+        entity_quoting = kwargs.get('entity_quoting', True)
         if 'entity_quoting' in kwargs:
             del kwargs['entity_quoting']
 


### PR DESCRIPTION
This just change pydal behaviour to enable entity quoting per-default.

@mdipierro @niphlod @ilvalle tests are passing, if you have any concerns speak now. This *should* be preferred since avoid a lot of troubles with reserved names for example.