### PR TITLE
[WIP] Indexes support

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -804,10 +804,12 @@ class SQLAdapter(BaseAdapter):
             index_name, table, expressions, **kwargs)
         self.execute(sql)
         self.commit()
+        return True
 
     def drop_index(self, table, index_name):
         sql = self.dialect.drop_index(index_name, table)
         self.execute(sql)
+        return True
 
     def distributed_transaction_begin(self, key):
         pass

--- a/pydal/adapters/couchdb.py
+++ b/pydal/adapters/couchdb.py
@@ -34,11 +34,11 @@ class CouchDB(NoSQLAdapter):
         super(CouchDB, self).create_table(
             table, migrate, fake_migrate, polymodel)
 
-    def expand(self, expression, field_type=None):
+    def _expand(self, expression, field_type=None):
         if isinstance(expression, Field):
             if expression.type == 'id':
                 return "%s._id" % expression.tablename
-        return SQLAdapter.expand(self, expression, field_type)
+        return SQLAdapter._expand(self, expression, field_type)
 
     def insert(self, table, fields):
         rid = uuid2int(self.db.uuid())

--- a/pydal/adapters/google.py
+++ b/pydal/adapters/google.py
@@ -173,7 +173,7 @@ class GoogleDatastore(NoSQLAdapter):
                 "polymodel must be None, True, a table or a tablename")
         return None
 
-    def expand(self, expression, field_type=None):
+    def _expand(self, expression, field_type=None):
         if expression is None:
             return None
         elif isinstance(expression, Field):

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -151,7 +151,7 @@ class Mongo(NoSQLAdapter):
         except (AttributeError, TypeError):
             return None
 
-    def expand(self, expression, field_type=None):
+    def _expand(self, expression, field_type=None):
         if isinstance(expression, Field):
             if expression.type == 'id':
                 result = "_id"

--- a/pydal/dialects/base.py
+++ b/pydal/dialects/base.py
@@ -432,9 +432,11 @@ class SQLDialect(CommonDialect):
 
     def create_index(self, name, table, expressions, unique=False):
         uniq = ' UNIQUE' if unique else ''
-        return 'CREATE%s INDEX %s ON %s (%s);' % (
-            uniq, self.quote(name), table.sqlsafe, ','.join(
-                self.expand(field) for field in expressions))
+        with self.adapter.index_expander():
+            rv = 'CREATE%s INDEX %s ON %s (%s);' % (
+                uniq, self.quote(name), table.sqlsafe, ','.join(
+                    self.expand(field) for field in expressions))
+        return rv
 
     def drop_index(self, name, table):
         return 'DROP INDEX %s;' % self.quote(name)

--- a/pydal/dialects/base.py
+++ b/pydal/dialects/base.py
@@ -422,13 +422,22 @@ class SQLDialect(CommonDialect):
     def primary_key(self, key):
         return 'PRIMARY KEY(%s)' % key
 
-    def drop(self, table, mode):
+    def drop_table(self, table, mode):
         return ['DROP TABLE %s;' % table.sqlsafe]
 
     def truncate(self, table, mode=''):
         if mode:
             mode = " %s" % mode
         return ['TRUNCATE TABLE %s%s;' % (table.sqlsafe, mode)]
+
+    def create_index(self, name, table, expressions, unique=False):
+        uniq = ' UNIQUE' if unique else ''
+        return 'CREATE%s INDEX %s ON %s (%s);' % (
+            uniq, self.quote(name), table.sqlsafe, ','.join(
+                self.expand(field) for field in expressions))
+
+    def drop_index(self, name, table):
+        return 'DROP INDEX %s;' % self.quote(name)
 
     def constraint_name(self, table, fieldname):
         return '%s_%s__constraint' % (table, fieldname)

--- a/pydal/dialects/firebird.py
+++ b/pydal/dialects/firebird.py
@@ -99,7 +99,7 @@ class FireBirdDialect(SQLDialect):
         return 'SELECT%s%s%s %s FROM %s%s%s%s%s;' % (
             dst, limit, offset, fields, tables, whr, grp, order, upd)
 
-    def drop(self, table, mode):
+    def drop_table(self, table, mode):
         sequence_name = table._sequence_name
         return [
             'DROP TABLE %s %s;' % (table.sqlsafe, mode),

--- a/pydal/dialects/mssql.py
+++ b/pydal/dialects/mssql.py
@@ -168,6 +168,9 @@ class MSSQLDialect(SQLDialect):
     def concat_add(self, tablename):
         return '; ALTER TABLE %s ADD ' % tablename
 
+    def drop_index(self, name, table):
+        return 'DROP INDEX %s ON %s;' % (self.quote(name), table.sqlsafe)
+
     def st_astext(self, first):
         return '%s.STAsText()' % self.expand(first)
 
@@ -217,7 +220,7 @@ class MSSQLNDialect(MSSQLDialect):
             second = self.expand(second, 'string').lower()
             if escape is None:
                 escape = '\\'
-                second = second.replace(escape, escape*2)
+                second = second.replace(escape, escape * 2)
         if second.startswith("n'"):
             second = "N'" + second[2:]
         return "(%s LIKE %s ESCAPE '%s')" % (

--- a/pydal/dialects/mysql.py
+++ b/pydal/dialects/mysql.py
@@ -75,8 +75,11 @@ class MySQLDialect(SQLDialect):
             second = 'CHAR'
         return 'CAST(%s AS %s)' % (first, second)
 
-    def drop(self, table, mode):
+    def drop_table(self, table, mode):
         # breaks db integrity but without this mysql does not drop table
         return [
             'SET FOREIGN_KEY_CHECKS=0;', 'DROP TABLE %s;' % table.sqlsafe,
             'SET FOREIGN_KEY_CHECKS=1;']
+
+    def drop_index(self, name, table):
+        return 'DROP INDEX %s ON %s;' % (self.quote(name), table.sqlsafe)

--- a/pydal/dialects/oracle.py
+++ b/pydal/dialects/oracle.py
@@ -111,7 +111,7 @@ class OracleDialect(SQLDialect):
         return 'SELECT%s %s FROM %s%s%s%s%s%s%s;' % (
             dst, fields, tables, whr, grp, order, limit, offset, upd)
 
-    def drop(self, table, mode):
+    def drop_table(self, table, mode):
         sequence_name = table._sequence_name
         return [
             'DROP TABLE %s %s;' % (table.sqlsafe, mode),

--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -109,7 +109,7 @@ class PostgreDialect(SQLDialect):
         return "(%s ILIKE %s ESCAPE '%s')" % (
             self.expand(first), second, escape)
 
-    def drop(self, table, mode):
+    def drop_table(self, table, mode):
         if mode not in ['restrict', 'cascade', '']:
             raise ValueError('Invalid mode: %s' % mode)
         return ['DROP TABLE ' + table.sqlsafe + ' ' + mode + ';']

--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -114,6 +114,15 @@ class PostgreDialect(SQLDialect):
             raise ValueError('Invalid mode: %s' % mode)
         return ['DROP TABLE ' + table.sqlsafe + ' ' + mode + ';']
 
+    def create_index(self, name, table, expressions, unique=False, where=None):
+        uniq = ' UNIQUE' if unique else ''
+        whr = ''
+        if where:
+            whr = ' %s' % self.where(where)
+        return 'CREATE%s INDEX %s ON %s (%s)%s;' % (
+            uniq, self.quote(name), table.sqlsafe, ','.join(
+                self.expand(field) for field in expressions), whr)
+
     def st_asgeojson(self, first, second):
         return 'ST_AsGeoJSON(%s,%s,%s,%s)' % (
             second['version'], self.expand(first), second['precision'],

--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -119,9 +119,11 @@ class PostgreDialect(SQLDialect):
         whr = ''
         if where:
             whr = ' %s' % self.where(where)
-        return 'CREATE%s INDEX %s ON %s (%s)%s;' % (
-            uniq, self.quote(name), table.sqlsafe, ','.join(
-                self.expand(field) for field in expressions), whr)
+        with self.adapter.index_expander():
+            rv = 'CREATE%s INDEX %s ON %s (%s)%s;' % (
+                uniq, self.quote(name), table.sqlsafe, ','.join(
+                    self.expand(field) for field in expressions), whr)
+        return rv
 
     def st_asgeojson(self, first, second):
         return 'ST_AsGeoJSON(%s,%s,%s,%s)' % (
@@ -253,7 +255,7 @@ class PostgreDialectArrays(PostgreDialect):
             args = (first, self.expand(second))
             return '(%s ILIKE %s)' % args
         return super(PostgreDialectArrays, self).ilike(
-                first, second, escape=escape)
+            first, second, escape=escape)
 
     def EQ(self, first, second=None):
         if first and 'type' not in first:

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1032,10 +1032,10 @@ class Table(Serializable, BasicStorage):
         return Expression(self._db, self._db._adapter.dialect.on, self, query)
 
     def create_index(self, name, *fields):
-        self._db._adapter.create_index(self, name, *fields)
+        return self._db._adapter.create_index(self, name, *fields)
 
     def drop_index(self, name):
-        self._db._adapter.drop_index(self, name)
+        return self._db._adapter.drop_index(self, name)
 
 
 def _expression_wrap(wrapper):

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1031,8 +1031,8 @@ class Table(Serializable, BasicStorage):
     def on(self, query):
         return Expression(self._db, self._db._adapter.dialect.on, self, query)
 
-    def create_index(self, name, *fields):
-        return self._db._adapter.create_index(self, name, *fields)
+    def create_index(self, name, *fields, **kwargs):
+        return self._db._adapter.create_index(self, name, *fields, **kwargs)
 
     def drop_index(self, name):
         return self._db._adapter.drop_index(self, name)

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -636,10 +636,10 @@ class Table(Serializable, BasicStorage):
         return self._db._adapter.sqlsafe_table(self._tablename, self._ot)
 
     def _drop(self, mode=''):
-        return self._db._adapter.dialect.drop(self, mode)
+        return self._db._adapter.dialect.drop_table(self, mode)
 
     def drop(self, mode=''):
-        return self._db._adapter.drop(self, mode)
+        return self._db._adapter.drop_table(self, mode)
 
     def _listify(self, fields, update=False):
         new_fields = {}  # format: new_fields[name] = (field, value)
@@ -1030,6 +1030,12 @@ class Table(Serializable, BasicStorage):
 
     def on(self, query):
         return Expression(self._db, self._db._adapter.dialect.on, self, query)
+
+    def create_index(self, name, *fields):
+        self._db._adapter.create_index(self, name, *fields)
+
+    def drop_index(self, name):
+        self._db._adapter.drop_index(self, name)
 
 
 def _expression_wrap(wrapper):

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1740,8 +1740,7 @@ class Query(Serializable):
         return self.db._adapter.dialect
 
     def __repr__(self):
-        from .adapters.base import BaseAdapter
-        return '<Query %s>' % BaseAdapter.expand(self.db._adapter, self)
+        return '<Query %s>' % str(self)
 
     def __str__(self):
         return str(self.db._adapter.expand(self))
@@ -1871,8 +1870,7 @@ class Set(Serializable):
         self.query = query
 
     def __repr__(self):
-        from .adapters.base import BaseAdapter
-        return '<Set %s>' % BaseAdapter.expand(self.db._adapter, self.query)
+        return '<Set %s>' % str(self.query)
 
     def __call__(self, query, ignore_common_filters=False):
         return self.where(query, ignore_common_filters)

--- a/pydal/utils.py
+++ b/pydal/utils.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+    pydal.utils
+    -----------
+
+    Provides some utilities for pydal.
+
+    :copyright: (c) 2016 by Giovanni Barillari and contributors
+    :license: BSD, see LICENSE for more details.
+"""
+
+import warnings
+
+
+class RemovedInNextVersionWarning(DeprecationWarning):
+    pass
+
+
+warnings.simplefilter('always', RemovedInNextVersionWarning)
+
+
+def warn_of_deprecation(old_name, new_name, prefix=None, stack=2):
+    msg = "%(old)s is deprecated, use %(new)s instead."
+    if prefix:
+        msg = "%(prefix)s." + msg
+    warnings.warn(
+        msg % {'old': old_name, 'new': new_name, 'prefix': prefix},
+        RemovedInNextVersionWarning, stack)
+
+
+class deprecated(object):
+    def __init__(self, old_method_name, new_method_name, class_name=None, s=0):
+        self.class_name = class_name
+        self.old_method_name = old_method_name
+        self.new_method_name = new_method_name
+        self.additional_stack = s
+
+    def __call__(self, f):
+        def wrapped(*args, **kwargs):
+            warn_of_deprecation(
+                self.old_method_name, self.new_method_name, self.class_name,
+                3 + self.additional_stack)
+            return f(*args, **kwargs)
+        return wrapped

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,7 @@ if NOSQL:
     from .nosql import *
 else:
     from .sql import *
+    from .indexes import *
 
 from .validation import *
 from .caching import TestCache

--- a/tests/indexes.py
+++ b/tests/indexes.py
@@ -1,0 +1,57 @@
+from pydal import DAL, Field
+from ._compat import unittest
+from ._adapt import DEFAULT_URI, IS_POSTGRESQL, drop
+
+
+class TestIndexesBasic(unittest.TestCase):
+    def testRun(self):
+        db = DAL(DEFAULT_URI, check_reserved=['all'])
+        db.define_table('tt', Field('aa'))
+        rv = db.tt.create_index('idx_aa', db.tt.aa)
+        self.assertTrue(rv)
+        rv = db.tt.drop_index('idx_aa')
+        self.assertTrue(rv)
+        with self.assertRaises(Exception):
+            db.tt.drop_index('idx_aa')
+        db.rollback()
+        drop(db.tt)
+
+
+@unittest.skipUnless(IS_POSTGRESQL, 'Only on Postgre')
+class TestIndexesExpressions(unittest.TestCase):
+    def testRun(self):
+        db = DAL(DEFAULT_URI, check_reserved=['all'], entity_quoting=True)
+        db.define_table('tt', Field('aa'), Field('bb', 'datetime'))
+        sql = db._adapter.dialect.create_index(
+            'idx_aa_and_bb', db.tt, [db.tt.aa, db.tt.bb.coalesce(None)]
+        )
+        self.assertEqual(
+            sql,
+            'CREATE INDEX "idx_aa_and_bb" ON "tt" ("tt"."aa",COALESCE("tt"."bb",NULL));'
+        )
+        rv = db.tt.create_index(
+            'idx_aa_and_bb', db.tt.aa, db.tt.bb.coalesce(None))
+        self.assertTrue(rv)
+        rv = db.tt.drop_index('idx_aa_and_bb')
+        self.assertTrue(rv)
+        drop(db.tt)
+
+
+@unittest.skipUnless(IS_POSTGRESQL, 'Only on Postgre')
+class TestIndexesWhere(unittest.TestCase):
+    def testRun(self):
+        db = DAL(DEFAULT_URI, check_reserved=['all'], entity_quoting=True)
+        db.define_table('tt', Field('aa'), Field('bb', 'boolean'))
+        sql = db._adapter.dialect.create_index(
+            'idx_aa_f', db.tt, [db.tt.aa], where=str(db.tt.bb == False)
+        )
+        self.assertEqual(
+            sql,
+            'CREATE INDEX "idx_aa_f" ON "tt" ("tt"."aa") WHERE ("tt"."bb" = \'F\');'
+        )
+        rv = db.tt.create_index(
+            'idx_aa_f', db.tt.aa, where=(db.tt.bb == False))
+        self.assertTrue(rv)
+        rv = db.tt.drop_index('idx_aa_f')
+        self.assertTrue(rv)
+        drop(db.tt)


### PR DESCRIPTION
**Don't merge this until I say is ready**

This implements basic indexes support as requested in #152.
Intended workflow:

```python
# just fields
db.mytable.create_index('index_name', db.mytable.myfield_a, db.mytable.myfield_b)
# with expressions
db.mytable.create_index('index_name', db.mytable.myfield_a, db.mytable.myfield_b.coalesce(None))
# with additional parameters (where is supported only by postgres)
db.mytable.create_index('index_name', db.mytable.myfield_a, where=(db.mytable.myfield_b == False), unique=True)

db.mytable.drop_index('index_name')
```

@niphlod @mdipierro @ilvalle @michele-comitini feedbacks are welcome.