### PR TITLE
Enabled entity quoting as default also on DAL class

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -10,7 +10,7 @@ from ..exceptions import NotOnNOSQLError
 from ..helpers.classes import Reference, ExecutionHandler, SQLCustomType, \
     SQLALL, NullDriver
 from ..helpers.methods import use_common_filters, xorify
-from ..helpers.regex import REGEX_SELECT_AS_PARSER
+from ..helpers.regex import REGEX_SELECT_AS_PARSER, REGEX_TABLE_DOT_FIELD
 from ..migrator import Migrator
 from ..objects import Table, Field, Expression, Query, Rows, IterRows, \
     LazySet, LazyReferenceGetter, VirtualCommand
@@ -159,7 +159,7 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
             if isinstance(item, SQLALL):
                 new_fields += item._table
             elif isinstance(item, str):
-                m = self.REGEX_TABLE_DOT_FIELD.match(item)
+                m = REGEX_TABLE_DOT_FIELD.match(item)
                 if m:
                     tablename, fieldname = m.groups()
                     append(self.db[tablename][fieldname])

--- a/pydal/base.py
+++ b/pydal/base.py
@@ -376,7 +376,7 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                  bigint_id=False, debug=False, lazy_tables=False,
                  db_uid=None, do_connect=True,
                  after_connection=None, tables=None, ignore_field_case=True,
-                 entity_quoting=False, table_hash=None):
+                 entity_quoting=True, table_hash=None):
 
         if uri == '<zombie>' and db_uid is not None:
             return


### PR DESCRIPTION
This is a missing piece of #360 

Also fixes select with strings and entity quoting, eg: `db(db.table).select('table.field')`