### PR TITLE
Fixes on blob uploads with python3, fixes on noSQL adapters and password fields

### DIFF
--- a/pydal/_compat.py
+++ b/pydal/_compat.py
@@ -10,6 +10,7 @@ if PY2:
     import cPickle as pickle
     from cStringIO import StringIO
     import copy_reg as copyreg
+    BytesIO = StringIO
     reduce = reduce
     hashlib_md5 = hashlib.md5
     iterkeys = lambda d: d.iterkeys()
@@ -46,7 +47,7 @@ if PY2:
         return obj.encode(charset, errors)
 else:
     import pickle
-    from io import StringIO
+    from io import StringIO, BytesIO
     import copyreg
     from functools import reduce
     hashlib_md5 = lambda s: hashlib.md5(bytes(s, 'utf8'))

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -11,9 +11,9 @@ import shutil
 import sys
 import types
 
-from ._compat import PY2, StringIO, pjoin, exists, hashlib_md5, \
+from ._compat import PY2, StringIO, BytesIO, pjoin, exists, hashlib_md5, \
     integer_types, basestring, iteritems, xrange, implements_iterator, \
-    implements_bool, copyreg, reduce, string_types
+    implements_bool, copyreg, reduce, string_types, to_bytes, to_native
 from ._globals import DEFAULT, IDENTITY, AND, OR
 from ._gae import Key
 from .exceptions import NotFoundException, NotAuthorizedException
@@ -706,7 +706,7 @@ class Table(Serializable, BasicStorage):
                             value.file, filename=value.filename)
                     elif isinstance(value, dict):
                         if 'data' in value and 'filename' in value:
-                            stream = StringIO(value['data'])
+                            stream = BytesIO(to_bytes(value['data']))
                             new_name = field.store(
                                 stream, filename=value['filename'])
                         else:
@@ -1502,8 +1502,8 @@ class Field(Expression, Serializable):
         m = REGEX_STORE_PATTERN.search(filename)
         extension = m and m.group('e') or 'txt'
         uuid_key = self._db.uuid().replace('-', '')[-16:]
-        encoded_filename = base64.b16encode(
-            filename.encode('utf-8')).lower().decode('utf-8')
+        encoded_filename = to_native(
+            base64.b16encode(to_bytes(filename)).lower())
         newfilename = '%s.%s.%s.%s' % (
             self._tablename, self.name, uuid_key, encoded_filename)
         newfilename = newfilename[:(self.length - 1 - len(extension))] + \
@@ -1564,12 +1564,12 @@ class Field(Expression, Serializable):
         file_properties = self.retrieve_file_properties(name, path)
         filename = file_properties['filename']
         if isinstance(self_uploadfield, str):  # ## if file is in DB
-            stream = StringIO(row[self_uploadfield] or '')
+            stream = BytesIO(to_bytes(row[self_uploadfield] or ''))
         elif isinstance(self_uploadfield, Field):
             blob_uploadfield_name = self_uploadfield.uploadfield
             query = self_uploadfield == name
             data = self_uploadfield.table(query)[blob_uploadfield_name]
-            stream = StringIO(data)
+            stream = BytesIO(to_bytes(data))
         elif self.uploadfs:
             # ## if file is on pyfilesystem
             stream = self.uploadfs.open(name, 'rb')

--- a/pydal/parsers/mongo.py
+++ b/pydal/parsers/mongo.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from .._compat import integer_types
+from .._compat import PY2, integer_types
 from ..adapters.mongo import Mongo, MongoBlob
 from ..helpers.classes import Reference
 from . import Parser, parsers, for_type, before_parse
@@ -17,7 +17,7 @@ class MongoParser(Parser):
 
     @for_type('blob')
     def _blob(self, value):
-        return MongoBlob.decode(value)
+        return MongoBlob.decode(value) if PY2 else value
 
     @before_parse('reference')
     def reference_extras(self, field_type):

--- a/pydal/representers/base.py
+++ b/pydal/representers/base.py
@@ -214,6 +214,10 @@ class NoSQLRepresenter(BaseRepresenter):
     def _string(self, value):
         return to_unicode(value)
 
+    @for_type('password')
+    def _password(self, value):
+        return to_unicode(value)
+
     @for_type('text')
     def _text(self, value):
         return to_unicode(value)

--- a/pydal/representers/mongo.py
+++ b/pydal/representers/mongo.py
@@ -1,5 +1,5 @@
 import datetime
-from .._compat import basestring
+from .._compat import PY2, basestring, to_bytes
 from ..adapters.mongo import Mongo, MongoBlob
 from ..helpers.classes import Reference
 from ..objects import Row
@@ -43,7 +43,7 @@ class MongoRepresenter(NoSQLRepresenter):
     def _blob(self, value):
         if isinstance(value, basestring) and value == '':
             value = None
-        return MongoBlob(value)
+        return MongoBlob(value) if PY2 else to_bytes(value)
 
     @for_type('list:reference')
     def _list_reference(self, value):


### PR DESCRIPTION
This fixes some issues:
- add missing representation of *password* fields on NoSQL adapters
- fixes blob uploads on python3
- changes blob handling on MongoDB and python3 since pymongo operates differently on this python version