### PR TITLE
Fix boolean parsing on postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
     - ADAPTER=postgres
     - ADAPTER=postgresPG8000
     - ADAPTER=postgres2
+    - ADAPTER=postgres3
+    - ADAPTER=postgres3PG8000
     - ADAPTER=google
     - ADAPTER=mongo
 
@@ -31,6 +33,8 @@ matrix:
       env: ADAPTER=postgres
     - python: 'pypy'
       env: ADAPTER=postgres2
+    - python: 'pypy'
+      env: ADAPTER=postgres3
     - python: 'pypy'
       env: ADAPTER=google
     - python: '3.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
     - ADAPTER=mysql
     - ADAPTER=postgres
     - ADAPTER=postgresPG8000
-    - ADAPTER=postgres2
     - ADAPTER=postgres3
     - ADAPTER=postgres3PG8000
     - ADAPTER=google
@@ -31,8 +30,6 @@ matrix:
   exclude:
     - python: 'pypy'
       env: ADAPTER=postgres
-    - python: 'pypy'
-      env: ADAPTER=postgres2
     - python: 'pypy'
       env: ADAPTER=postgres3
     - python: 'pypy'

--- a/pydal/adapters/postgres.py
+++ b/pydal/adapters/postgres.py
@@ -205,6 +205,27 @@ class PostgrePG8000New(PostgrePG8000):
     pass
 
 
+@adapters.register_for('postgres3')
+class PostgreBoolean(PostgreNew):
+    def _get_json_dialect(self):
+        from ..dialects.postgre import PostgreDialectBooleanJSON
+        return PostgreDialectBooleanJSON
+
+    def _get_json_parser(self):
+        from ..parsers.postgre import PostgreBooleanAutoJSONParser
+        return PostgreBooleanAutoJSONParser
+
+
+@adapters.register_for('postgres3:psycopg2')
+class PostgrePsycoBoolean(PostgrePsycoNew):
+    pass
+
+
+@adapters.register_for('postgres3:pg8000')
+class PostgrePG8000Boolean(PostgrePG8000New):
+    pass
+
+
 @adapters.register_for('jdbc:postgres')
 class JDBCPostgre(Postgre):
     drivers = ('zxJDBC',)

--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -1,4 +1,4 @@
-from ..adapters.postgres import Postgre, PostgreNew
+from ..adapters.postgres import Postgre, PostgreNew, PostgreBoolean
 from ..helpers.methods import varquote_aux
 from ..objects import Expression
 from .base import SQLDialect
@@ -264,6 +264,19 @@ class PostgreDialectArrays(PostgreDialect):
 
 
 class PostgreDialectArraysJSON(PostgreDialectArrays):
+    @sqltype_for('json')
+    def type_json(self):
+        return 'JSON'
+
+
+@dialects.register_for(PostgreBoolean)
+class PostgreDialectBoolean(PostgreDialectArrays):
+    @sqltype_for('boolean')
+    def type_boolean(self):
+        return 'BOOLEAN'
+
+
+class PostgreDialectBooleanJSON(PostgreDialectBoolean):
     @sqltype_for('json')
     def type_json(self):
         return 'JSON'

--- a/pydal/parsers/base.py
+++ b/pydal/parsers/base.py
@@ -30,8 +30,7 @@ class BasicParser(Parser):
 
     @for_type('boolean')
     def _boolean(self, value):
-        return value == self.dialect.true
-        # or str(value)[:1].lower() == 't'
+        return value == self.dialect.true or str(value)[:1].lower() == 't'
 
     @for_type('blob')
     def _blob(self, value):

--- a/pydal/parsers/postgre.py
+++ b/pydal/parsers/postgre.py
@@ -1,6 +1,6 @@
-from ..adapters.postgres import Postgre, PostgreNew
+from ..adapters.postgres import Postgre, PostgreNew, PostgreBoolean
 from .base import BasicParser, ListsParser, JSONParser
-from . import parsers
+from . import parsers, for_type
 
 
 @parsers.register_for(Postgre)
@@ -19,3 +19,16 @@ class PostgreNewParser(JSONParser):
 
 class PostgreNewAutoJSONParser(BasicParser):
     pass
+
+
+@parsers.register_for(PostgreBoolean)
+class PostgreBooleanParser(JSONParser):
+    @for_type('boolean')
+    def _boolean(self, value):
+        return value
+
+
+class PostgreBooleanAutoJSONParser(BasicParser):
+    @for_type('boolean')
+    def _boolean(self, value):
+        return value

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,pypy,py33,py34}-{sqlite,mongo,postgresPG8000,postgres3PG8000,mysql}, {py27,py33,py34}-{postgres,postgres2,postgres3}, py27-{google,mssql}
+envlist = {py27,pypy,py33,py34}-{sqlite,mongo,postgresPG8000,postgres3PG8000,mysql}, {py27,py33,py34}-{postgres,postgres3}, py27-{google,mssql}
 
 [testenv]
 setenv =
@@ -7,7 +7,6 @@ setenv =
     mysql: DB=mysql://root:@localhost/pydal
     postgres: DB=postgres://postgres:@localhost/pydal
     postgresPG8000: DB=postgres:pg8000://postgres:@localhost/pydal
-    postgres2: DB=postgres2:psycopg2://postgres:@localhost/pydal
     postgres3: DB=postgres3:psycopg2://postgres:@localhost/pydal
     postgres3PG8000: DB=postgres3:pg8000://postgres:@localhost/pydal
     google: DB=google:datastore
@@ -17,7 +16,6 @@ setenv =
 deps =
     mysql: pymysql
     postgres: psycopg2
-    postgres2: psycopg2
     postgres3: psycopg2
     postgresPG8000: pg8000
     postgres3PG8000: pg8000

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,pypy,py33,py34}-{sqlite,mongo,postgresPG8000,mysql}, {py27,py33,py34}-{postgres,postgres2}, py27-{google,mssql}
+envlist = {py27,pypy,py33,py34}-{sqlite,mongo,postgresPG8000,postgres3PG8000,mysql}, {py27,py33,py34}-{postgres,postgres2,postgres3}, py27-{google,mssql}
 
 [testenv]
 setenv =
@@ -8,6 +8,8 @@ setenv =
     postgres: DB=postgres://postgres:@localhost/pydal
     postgresPG8000: DB=postgres:pg8000://postgres:@localhost/pydal
     postgres2: DB=postgres2:psycopg2://postgres:@localhost/pydal
+    postgres3: DB=postgres3:psycopg2://postgres:@localhost/pydal
+    postgres3PG8000: DB=postgres3:pg8000://postgres:@localhost/pydal
     google: DB=google:datastore
     mongo: DB=mongodb://localhost/pydal
     mssql: DB=mssql4://sa:Password12!@(local)\SQL2014/pydal
@@ -16,7 +18,9 @@ deps =
     mysql: pymysql
     postgres: psycopg2
     postgres2: psycopg2
+    postgres3: psycopg2
     postgresPG8000: pg8000
+    postgres3PG8000: pg8000
     google: pyyaml
     mongo: pymongo
     mssql: pypyodbc


### PR DESCRIPTION
As discussed on the group: https://groups.google.com/forum/#!topic/web2py-developers/m2MV5Y12lhM

This:
- puts back the parsing of multiple boolean types in the base parser
- adds a *postgres3* adapter which uses the *BOOLEAN* type of PostgreSQL for *boolean* fields

I removed the tests for *postgres2* adapter since is implicitly tested by *postgres3* as it inherits from *postgres2*.