### PR TITLE
Added field type 'list:double'

### DIFF
--- a/pydal/dialects/base.py
+++ b/pydal/dialects/base.py
@@ -113,6 +113,10 @@ class SQLDialect(CommonDialect):
     @sqltype_for('list:integer')
     def type_list_integer(self):
         return self.types['text']
+        
+    @sqltype_for('list:double')
+    def type_list_double(self):
+        return self.types['text']
 
     @sqltype_for('list:string')
     def type_list_string(self):
@@ -517,6 +521,10 @@ class NoSQLDialect(CommonDialect):
 
     @sqltype_for('list:integer')
     def type_list_integer(self):
+        return list
+        
+    @sqltype_for('list:double')
+    def type_list_double(self):
         return list
 
     @sqltype_for('list:string')

--- a/pydal/helpers/methods.py
+++ b/pydal/helpers/methods.py
@@ -78,6 +78,12 @@ def bar_decode_integer(value):
     if not hasattr(value, 'split') and hasattr(value, 'read'):
         value = value.read()
     return [long(x) for x in value.split('|') if x.strip()]
+    
+    
+def bar_decode_double(value):
+    if not hasattr(value, 'split') and hasattr(value, 'read'):
+        value = value.read()
+    return [float(x) for x in value.split('|') if x.strip()]
 
 
 def bar_decode_string(value):

--- a/pydal/parsers/base.py
+++ b/pydal/parsers/base.py
@@ -136,6 +136,10 @@ class ListsParser(BasicParser):
     @for_type('list:integer')
     def _list_integers(self, value):
         return bar_decode_integer(value)
+        
+    @for_type('list:double')
+    def _list_doubles(self, value):
+        return bar_decode_double(value)
 
     @for_type('list:string')
     def _list_strings(self, value):

--- a/pydal/representers/base.py
+++ b/pydal/representers/base.py
@@ -71,6 +71,12 @@ class BaseRepresenter(Representer):
         values = self._ensure_list(value)
         values = list(map(int, [val for val in values if val != '']))
         return bar_encode(value)
+        
+    @for_type('list:double')
+    def _list_double(self, value):
+        values = self._ensure_list(value)
+        values = list(map(float, [val for val in values if val != '']))
+        return bar_encode(values)
 
     @for_type('list:string')
     def _list_string(self, value):
@@ -273,6 +279,11 @@ class NoSQLRepresenter(BaseRepresenter):
     def _list_integer(self, value):
         values = self._represent_list(value)
         return list(map(int, values))
+        
+    @for_type('list:double')
+    def _list_double(self, value):
+        values = self._represent_list(value)
+        return list(map(float, values))
 
     @for_type('list:string')
     def _list_string(self, value):

--- a/pydal/representers/base.py
+++ b/pydal/representers/base.py
@@ -70,7 +70,7 @@ class BaseRepresenter(Representer):
     def _list_integer(self, value):
         values = self._ensure_list(value)
         values = list(map(int, [val for val in values if val != '']))
-        return bar_encode(value)
+        return bar_encode(values)
         
     @for_type('list:double')
     def _list_double(self, value):


### PR DESCRIPTION
It seemed like an oversight that this field type didn't already exist. It should be useful for e.g. lists of currency amounts, percentages, and vectors.