### PR TITLE
to_unicode: try to use decode method before falling_back to text_type

### DIFF
--- a/pydal/_compat.py
+++ b/pydal/_compat.py
@@ -86,9 +86,10 @@ def with_metaclass(meta, *bases):
 def to_unicode(obj, charset='utf-8', errors='strict'):
     if obj is None:
         return None
-    if not isinstance(obj, bytes):
+    try:
+        return obj.decode(charset, errors)
+    except AttributeError:
         return text_type(obj)
-    return obj.decode(charset, errors)
 
 
 # shortcuts


### PR DESCRIPTION
This generalized the case of `bytes` for object that support `decode` method.

It seems to solve the issue #403.