### PR TITLE
Joinable subselects

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -126,14 +126,14 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
         return tables
 
     def get_table(self, *queries):
-        tablenames = self.tables(*queries)
-        if len(tablenames) == 1:
-            return tablenames.popitem()[0]
-        elif len(tablenames) < 1:
+        tablemap = self.tables(*queries)
+        if len(tablemap) == 1:
+            return tablemap.popitem()[1]
+        elif len(tablemap) < 1:
             raise RuntimeError("No table selected")
         else:
             raise RuntimeError(
-                "Too many tables selected (%s)" % str(tablenames))
+                "Too many tables selected (%s)" % str(list(tablemap)))
 
     def common_filter(self, query, tablist):
         tenant_fieldname = self.db._request_tenant

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -595,10 +595,9 @@ class SQLAdapter(BaseAdapter):
                       cache=None, cacheable=None, processor=None):
         #: parse tablemap
         tablemap = self.tables(query)
-        tablenames_for_common_filters = tablemap
         #: apply common filters if needed
         if use_common_filters(query):
-            query = self.common_filter(query, tablenames_for_common_filters)
+            query = self.common_filter(query, list(tablemap.values()))
         #: expand query if needed
         if query:
             query = self.expand(query)

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -512,7 +512,7 @@ class SQLAdapter(BaseAdapter):
     def _update(self, table, query, fields):
         sql_q = ''
         tablename = table.sqlsafe
-        query_env = dict(current_scope=[tablename])
+        query_env = dict(current_scope=[table._tablename])
         if query:
             if use_common_filters(query):
                 query = self.common_filter(query, [table])
@@ -540,7 +540,7 @@ class SQLAdapter(BaseAdapter):
     def _delete(self, table, query):
         sql_q = ''
         tablename = table.sqlsafe
-        query_env = dict(current_scope=[tablename])
+        query_env = dict(current_scope=[table._tablename])
         if query:
             if use_common_filters(query):
                 query = self.common_filter(query, [table])

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -604,8 +604,7 @@ class SQLAdapter(BaseAdapter):
         if query:
             query = self.expand(query)
         #: auto-adjust tables
-        for field in fields:
-            tablemap = merge_tablemaps(tablemap, self.tables(field))
+        tablemap = merge_tablemaps(tablemap, self.tables(*fields))
         if len(tablemap) < 1:
             raise SyntaxError('Set: no tables selected')
         #: remove outer scoped tables if needed

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -715,6 +715,9 @@ class SQLAdapter(BaseAdapter):
     def _select(self, query, fields, attributes):
         return self._select_wcols(query, fields, **attributes)[1]
 
+    def nested_select(self, query, fields, attributes):
+        return Select(self.db, query, fields, attributes)
+
     def _select_aux_execute(self, sql):
         self.execute(sql)
         return self.cursor.fetchall()
@@ -948,6 +951,10 @@ class NoSQLAdapter(BaseAdapter):
         return self.drop_table(table, mode='')
 
     def _select(self, *args, **kwargs):
+        raise NotOnNOSQLError(
+            "Nested queries are not supported on NoSQL databases")
+
+    def nested_select(self, *args, **kwargs):
         raise NotOnNOSQLError(
             "Nested queries are not supported on NoSQL databases")
 

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -709,7 +709,7 @@ class SQLAdapter(BaseAdapter):
         )
 
     def _select(self, query, fields, attributes):
-        return Select(self.db, query, fields, attributes)
+        return self._select_wcols(query, fields, **attributes)[1]
 
     def _select_aux_execute(self, sql):
         self.execute(sql)

--- a/pydal/adapters/couchdb.py
+++ b/pydal/adapters/couchdb.py
@@ -34,11 +34,12 @@ class CouchDB(NoSQLAdapter):
         super(CouchDB, self).create_table(
             table, migrate, fake_migrate, polymodel)
 
-    def _expand(self, expression, field_type=None):
+    def _expand(self, expression, field_type=None, query_env={}):
         if isinstance(expression, Field):
             if expression.type == 'id':
                 return "%s._id" % expression.tablename
-        return SQLAdapter._expand(self, expression, field_type)
+        return SQLAdapter._expand(self, expression, field_type,
+            query_env=query_env)
 
     def insert(self, table, fields):
         rid = uuid2int(self.db.uuid())

--- a/pydal/adapters/couchdb.py
+++ b/pydal/adapters/couchdb.py
@@ -67,7 +67,7 @@ class CouchDB(NoSQLAdapter):
                 new_fields.append(item)
 
         fields = new_fields
-        tablename = self.get_table(query)
+        tablename = self.get_table(query)._tablename
         fieldnames = [f.name for f in (fields or self.db[tablename])]
         colnames = [
             '%s.%s' % (tablename, fieldname) for fieldname in fieldnames]
@@ -105,7 +105,7 @@ class CouchDB(NoSQLAdapter):
                 return 1
             except couchdb.http.ResourceNotFound:
                 return 0
-        tablename = self.get_table(query)
+        tablename = self.get_table(query)._tablename
         rows = self.select(query, [self.db[tablename]._id], {})
         ctable = self.connection[tablename]
         table = self.db[tablename]
@@ -121,7 +121,7 @@ class CouchDB(NoSQLAdapter):
             raise RuntimeError("COUNT DISTINCT not supported")
         if not isinstance(query, Query):
             raise SyntaxError("Not Supported")
-        tablename = self.get_table(query)
+        tablename = self.get_table(query)._tablename
         rows = self.select(query, [self.db[tablename]._id], {})
         return len(rows)
 
@@ -139,7 +139,7 @@ class CouchDB(NoSQLAdapter):
                 return 1
             except couchdb.http.ResourceNotFound:
                 return 0
-        tablename = self.get_table(query)
+        tablename = self.get_table(query)._tablename
         rows = self.select(query, [self.db[tablename]._id], {})
         ctable = self.connection[tablename]
         for row in rows:

--- a/pydal/adapters/couchdb.py
+++ b/pydal/adapters/couchdb.py
@@ -89,7 +89,7 @@ class CouchDB(NoSQLAdapter):
         processor = attributes.get('processor', self.parse)
         return processor(rows, fields, colnames, False)
 
-    def update(self, tablename, query, fields):
+    def update(self, table, query, fields):
         from ..drivers import couchdb
         if not isinstance(query, Query):
             raise SyntaxError("Not Supported")
@@ -126,7 +126,7 @@ class CouchDB(NoSQLAdapter):
         rows = self.select(query, [self.db[tablename]._id], {})
         return len(rows)
 
-    def delete(self, tablename, query):
+    def delete(self, table, query):
         from ..drivers import couchdb
         if not isinstance(query, Query):
             raise SyntaxError("Not Supported")

--- a/pydal/adapters/google.py
+++ b/pydal/adapters/google.py
@@ -384,7 +384,7 @@ class GoogleDatastore(NoSQLAdapter):
         items, table, fields = self.select_raw(query, count_only=True)
         return items[0]
 
-    def delete(self, tablename, query):
+    def delete(self, table, query):
         """
         This function was changed on 2010-05-04 because according to
         http://code.google.com/p/googleappengine/issues/detail?id=3119
@@ -406,7 +406,7 @@ class GoogleDatastore(NoSQLAdapter):
             ndb.delete_multi([item.key for item in items])
         return counter
 
-    def update(self, tablename, query, update_fields):
+    def update(self, table, query, update_fields):
         items, table, fields = self.select_raw(query)
         counter = 0
         for item in items:

--- a/pydal/adapters/google.py
+++ b/pydal/adapters/google.py
@@ -172,7 +172,7 @@ class GoogleDatastore(NoSQLAdapter):
                 "polymodel must be None, True, a table or a tablename")
         return None
 
-    def _expand(self, expression, field_type=None):
+    def _expand(self, expression, field_type=None, query_env={}):
         if expression is None:
             return None
         elif isinstance(expression, Field):
@@ -182,9 +182,10 @@ class GoogleDatastore(NoSQLAdapter):
             return expression.name
         elif isinstance(expression, (Expression, Query)):
             if expression.second is not None:
-                return expression.op(expression.first, expression.second)
+                return expression.op(expression.first, expression.second,
+                    query_env=query_env)
             elif expression.first is not None:
-                return expression.op(expression.first)
+                return expression.op(expression.first, query_env=query_env)
             else:
                 return expression.op()
         elif field_type:

--- a/pydal/adapters/google.py
+++ b/pydal/adapters/google.py
@@ -243,24 +243,24 @@ class GoogleDatastore(NoSQLAdapter):
 
         fields = new_fields
         if query:
-            tablename = self.get_table(query)
+            table = self.get_table(query)
         elif fields:
-            tablename = fields[0].tablename
+            table = fields[0].table
             query = db._adapter.id_query(fields[0].table)
         else:
-            raise SyntaxError("Unable to determine a tablename")
+            raise SyntaxError("Unable to determine the table")
 
         if query:
             if use_common_filters(query):
-                query = self.common_filter(query, [tablename])
+                query = self.common_filter(query, [table])
 
         #tableobj is a GAE/NDB Model class (or subclass)
-        tableobj = db[tablename]._tableobj
+        tableobj = table._tableobj
         filters = self.expand(query)
 
         ## DETERMINE PROJECTION
         projection = None
-        if len(db[tablename].fields) == len(fields):
+        if len(table.fields) == len(fields):
             # getting all fields, not a projection query
             projection = None
         elif args_get('projection') == True:
@@ -271,18 +271,18 @@ class GoogleDatastore(NoSQLAdapter):
                         "text and blob field types not allowed in " +
                         "projection queries")
                 else:
-                    projection.append(f.name)
+                    projection.append(f)
 
         elif args_get('filterfields') is True:
             projection = []
             for f in fields:
-                projection.append(f.name)
+                projection.append(f)
 
         # real projection's can't include 'id'.
         # it will be added to the result later
         if projection and args_get('projection') == True:
-            query_projection = filter(lambda p: p != db[tablename]._id.name,
-                                      projection)
+            query_projection = [f.name for f in projection
+                    if f.name != table._id.name]
         else:
             query_projection = None
         ## DONE WITH PROJECTION
@@ -339,7 +339,7 @@ class GoogleDatastore(NoSQLAdapter):
                 # didn't return all results
                 if args_get('reusecursor'):
                     db['_lastcursor'] = cursor
-        return (items, tablename, projection or db[tablename].fields)
+        return (items, table, projection or [f for f in table])
 
     def select(self, query, fields, attributes):
         """
@@ -366,21 +366,21 @@ class GoogleDatastore(NoSQLAdapter):
           https://developers.google.com/appengine/docs/python/datastore/queries#Query_Cursors
         """
 
-        items, tablename, fields = self.select_raw(query, fields, attributes)
+        items, table, fields = self.select_raw(query, fields, attributes)
         rows = [
             [
-                (t == self.db[tablename]._id.name and item) or
-                (t == 'nativeRef' and item) or getattr(item, t)
+                (t.name == table._id.name and item) or
+                (t.name == 'nativeRef' and item) or getattr(item, t.name)
                 for t in fields
             ] for item in items]
-        colnames = ['%s.%s' % (tablename, t) for t in fields]
+        colnames = ['%s.%s' % (table._tablename, t.name) for t in fields]
         processor = attributes.get('processor', self.parse)
         return processor(rows, fields, colnames, False)
 
     def count(self, query, distinct=None, limit=None):
         if distinct:
             raise RuntimeError("COUNT DISTINCT not supported")
-        items, tablename, fields = self.select_raw(query, count_only=True)
+        items, table, fields = self.select_raw(query, count_only=True)
         return items[0]
 
     def delete(self, tablename, query):
@@ -389,7 +389,7 @@ class GoogleDatastore(NoSQLAdapter):
         http://code.google.com/p/googleappengine/issues/detail?id=3119
         GAE no longer supports deleting more than 1000 records.
         """
-        items, tablename, fields = self.select_raw(query)
+        items, table, fields = self.select_raw(query)
         # items can be one item or a query
         if not isinstance(items, list):
             # use a keys_only query to ensure that this runs as a datastore
@@ -406,7 +406,7 @@ class GoogleDatastore(NoSQLAdapter):
         return counter
 
     def update(self, tablename, query, update_fields):
-        items, tablename, fields = self.select_raw(query)
+        items, table, fields = self.select_raw(query)
         counter = 0
         for item in items:
             for field, value in update_fields:

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -240,7 +240,7 @@ class Mongo(NoSQLAdapter):
             else:
                 new_fields.append(item)
         fields = new_fields
-        tablename = self.get_table(query, *fields)
+        tablename = self.get_table(query, *fields)._tablename
 
         if for_update:
             self.db.logger.warning(
@@ -607,7 +607,8 @@ class Expansion(object):
             self.fields = [self.annotate_expression(f)
                            for f in (fields or [])]
 
-        self.tablename = tablename or adapter.get_table(query, *self.fields)
+        self.tablename = (tablename or
+                adapter.get_table(query, *self.fields)._tablename)
         if use_common_filters(query):
             query = adapter.common_filter(query, [self.tablename])
         self.query = self.annotate_expression(query)

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -148,7 +148,7 @@ class Mongo(NoSQLAdapter):
         except (AttributeError, TypeError):
             return None
 
-    def _expand(self, expression, field_type=None):
+    def _expand(self, expression, field_type=None, query_env={}):
         if isinstance(expression, Field):
             if expression.type == 'id':
                 result = "_id"
@@ -169,6 +169,7 @@ class Mongo(NoSQLAdapter):
                     second = self.object_id(expression.second)
             op = expression.op
             optional_args = expression.optional_args or {}
+            optional_args['query_env'] = query_env
             if second is not None:
                 result = op(first, second, **optional_args)
             elif first is not None:
@@ -178,7 +179,8 @@ class Mongo(NoSQLAdapter):
             else:
                 result = op(**optional_args)
         elif isinstance(expression, Expansion):
-            expression.query = (self.expand(expression.query, field_type))
+            expression.query = (self.expand(expression.query, field_type,
+                query_env=query_env))
             result = expression
         elif isinstance(expression, (list, tuple)):
             raise NotImplementedError("How did you reach this line of code???")

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -429,7 +429,7 @@ class Mongo(NoSQLAdapter):
         else:
             return None
 
-    def update(self, tablename, query, fields, safe=None):
+    def update(self, table, query, fields, safe=None):
         # return amount of adjusted rows or zero, but no exceptions
         # @ related not finding the result
         if not isinstance(query, Query):
@@ -468,7 +468,7 @@ class Mongo(NoSQLAdapter):
             raise RuntimeError(
                 "uncaught exception when updating rows: %s" % e)
 
-    def delete(self, tablename, query, safe=None):
+    def delete(self, table, query, safe=None):
         if not isinstance(query, Query):
             raise RuntimeError("query type %s is not supported" % type(query))
 
@@ -482,11 +482,10 @@ class Mongo(NoSQLAdapter):
 
         # find references to deleted items
         db = self.db
-        table = db[tablename]
         cascade = []
         set_null = []
         for field in table._referenced_by:
-            if field.type == 'reference ' + tablename:
+            if field.type == 'reference ' + table._tablename:
                 if field.ondelete == 'CASCADE':
                     cascade.append(field)
                 if field.ondelete == 'SET NULL':
@@ -494,7 +493,7 @@ class Mongo(NoSQLAdapter):
         cascade_list = []
         set_null_list = []
         for field in table._referenced_by_list:
-            if field.type == 'list:reference ' + tablename:
+            if field.type == 'list:reference ' + table._tablename:
                 if field.ondelete == 'CASCADE':
                     cascade_list.append(field)
                 if field.ondelete == 'SET NULL':

--- a/pydal/adapters/sqlite.py
+++ b/pydal/adapters/sqlite.py
@@ -81,14 +81,13 @@ class SQLite(SQLAdapter):
             self.execute('BEGIN IMMEDIATE TRANSACTION;')
         return super(SQLite, self).select(query, fields, attributes)
 
-    def delete(self, tablename, query):
+    def delete(self, table, query):
         db = self.db
-        table = db[tablename]
         deleted = [x[table._id.name] for x in db(query).select(table._id)]
-        counter = super(SQLite, self).delete(tablename, query)
+        counter = super(SQLite, self).delete(table, query)
         if counter:
             for field in table._referenced_by:
-                if field.type == 'reference ' + tablename \
+                if field.type == 'reference ' + table._tablename \
                    and field.ondelete == 'CASCADE':
                     db(field.belongs(deleted)).delete()
         return counter

--- a/pydal/dialects/base.py
+++ b/pydal/dialects/base.py
@@ -235,6 +235,9 @@ class SQLDialect(CommonDialect):
         if isinstance(second, str):
             return '(%s IN (%s))' % (first, second[:-1])
         elif isinstance(second, Select):
+            if len(second._qfields) != 1:
+                raise ValueError(
+                    'Subquery in belongs() must select exactly 1 column')
             sub = second._compile(query_env.get('current_scope', []))[1][:-1]
             return '(%s IN (%s))' % (first, sub)
         if not second:

--- a/pydal/dialects/couchdb.py
+++ b/pydal/dialects/couchdb.py
@@ -5,23 +5,28 @@ from . import dialects
 
 @dialects.register_for(CouchDB)
 class CouchDBDialect(NoSQLDialect):
-    def _and(self, first, second):
-        return '(%s && %s)' % (self.expand(first), self.expand(second))
+    def _and(self, first, second, query_env={}):
+        return '(%s && %s)' % (self.expand(first, query_env=query_env),
+            self.expand(second, query_env=query_env))
 
-    def _or(self, first, second):
-        return '(%s || %s)' % (self.expand(first), self.expand(second))
+    def _or(self, first, second, query_env={}):
+        return '(%s || %s)' % (self.expand(first, query_env=query_env),
+            self.expand(second, query_env=query_env))
 
-    def eq(self, first, second=None):
+    def eq(self, first, second=None, query_env={}):
         if second is None:
-            return '(%s == null)' % self.expand(first)
+            return '(%s == null)' % self.expand(first, query_env=query_env)
         return '(%s == %s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def ne(self, first, second=None):
+    def ne(self, first, second=None, query_env={}):
         if second is None:
-            return '(%s != null)' % self.expand(first)
+            return '(%s != null)' % self.expand(first, query_env=query_env)
         return '(%s != %s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def comma(self, first, second):
-        return '%s + %s' % (self.expand(first), self.expand(second))
+    def comma(self, first, second, query_env={}):
+        return '%s + %s' % (self.expand(first, query_env=query_env),
+            self.expand(second, query_env=query_env))

--- a/pydal/dialects/db2.py
+++ b/pydal/dialects/db2.py
@@ -1,3 +1,4 @@
+from .._compat import basestring
 from ..adapters.db2 import DB2
 from .base import SQLDialect
 from . import dialects, sqltype_for
@@ -51,7 +52,10 @@ class DB2Dialect(SQLDialect):
             '(%(field_name)s) REFERENCES %(foreign_table)s' + \
             '(%(foreign_key)s) ON DELETE %(on_delete_action)s'
 
-    def left_join(self, val):
+    def left_join(self, val, query_env={}):
+        # Left join must always have an ON clause
+        if not isinstance(val, basestring):
+            val = self.expand(val, query_env=query_env)
         return 'LEFT OUTER JOIN %s' % val
 
     @property

--- a/pydal/dialects/firebird.py
+++ b/pydal/dialects/firebird.py
@@ -58,22 +58,25 @@ class FireBirdDialect(SQLDialect):
         return 'DEFAULT %s NOT NULL' % \
             self.adapter.represent(default, field_type)
 
-    def epoch(self, val):
-        return "DATEDIFF(second, '1970-01-01 00:00:00', %s)" % self.expand(val)
+    def epoch(self, val, query_env={}):
+        return "DATEDIFF(second, '1970-01-01 00:00:00', %s)" % \
+            self.expand(val, query_env=query_env)
 
-    def substring(self, field, parameters):
+    def substring(self, field, parameters, query_env={}):
         return 'SUBSTRING(%s from %s for %s)' % (
-            self.expand(field), parameters[0], parameters[1])
+            self.expand(field, query_env=query_env), parameters[0],
+            parameters[1])
 
-    def length(self, val):
-        return "CHAR_LENGTH(%s)" % self.expand(val)
+    def length(self, val, query_env={}):
+        return "CHAR_LENGTH(%s)" % self.expand(val, query_env=query_env)
 
-    def contains(self, first, second, case_sensitive=True):
+    def contains(self, first, second, case_sensitive=True, query_env={}):
         if first.type.startswith('list:'):
             second = Expression(None, self.concat('|', Expression(
-                None, self.replace(second, ('|', '||'))), '|'))
+                None, self.replace(second, ('|', '||'), query_env)), '|'))
         return '(%s CONTAINING %s)' % (
-            self.expand(first), self.expand(second, 'string'))
+            self.expand(first, query_env=query_env),
+            self.expand(second, 'string', query_env=query_env))
 
     def select(self, fields, tables, where=None, groupby=None, having=None,
                orderby=None, limitby=None, distinct=False, for_update=False):

--- a/pydal/dialects/google.py
+++ b/pydal/dialects/google.py
@@ -100,17 +100,17 @@ class GoogleDatastoreDialect(NoSQLDialect):
         return (lambda **kwargs: ndb.IntegerProperty(
             repeated=True, default=None, **kwargs))
 
-    def _and(self, first, second):
-        first = self.expand(first)
-        second = self.expand(second)
+    def _and(self, first, second, query_env={}):
+        first = self.expand(first, query_env=query_env)
+        second = self.expand(second, query_env=query_env)
         # none means lack of query (true)
         if first == None:
             return second
         return ndb.AND(first, second)
 
-    def _or(self, first, second):
-        first = self.expand(first)
-        second = self.expand(second)
+    def _or(self, first, second, query_env={}):
+        first = self.expand(first, query_env=query_env)
+        second = self.expand(second, query_env=query_env)
         # none means lack of query (true)
         if first == None or second == None:
             return None
@@ -124,31 +124,31 @@ class GoogleDatastoreDialect(NoSQLDialect):
         value = self.adapter.represent(second, first.type, first._tablename)
         return self.FILTER_OPTIONS[op](field, value)
 
-    def eq(self, first, second=None):
+    def eq(self, first, second=None, query_env={}):
         return self.__gaef(first, '=', second)
 
-    def ne(self, first, second=None):
+    def ne(self, first, second=None, query_env={}):
         return self.__gaef(first, '!=', second)
 
-    def lt(self, first, second=None):
+    def lt(self, first, second=None, query_env={}):
         return self.__gaef(first, '<', second)
 
-    def lte(self, first, second=None):
+    def lte(self, first, second=None, query_env={}):
         return self.__gaef(first, '<=', second)
 
-    def gt(self, first, second=None):
+    def gt(self, first, second=None, query_env={}):
         return self.__gaef(first, '>', second)
 
-    def gte(self, first, second=None):
+    def gte(self, first, second=None, query_env={}):
         return self.__gaef(first, '>=', second)
 
-    def invert(self, first):
+    def invert(self, first, query_env={}):
         return '-%s' % first.name
 
-    def comma(self, first, second):
+    def comma(self, first, second, query_env={}):
         return '%s,%s' % (first, second)
 
-    def belongs(self, first, second):
+    def belongs(self, first, second, query_env={}):
         if not isinstance(second, (list, tuple, set)):
             raise SyntaxError("Not supported")
         if not isinstance(second, list):
@@ -160,13 +160,13 @@ class GoogleDatastoreDialect(NoSQLDialect):
             return f
         return self.__gaef(first, 'in', second)
 
-    def contains(self, first, second, case_sensitive=True):
+    def contains(self, first, second, case_sensitive=True, query_env={}):
         # silently ignoring: GAE can only do case sensitive matches!
         if not first.type.startswith('list:'):
             raise SyntaxError("Not supported")
         return self.__gaef(first, '=', second)
 
-    def _not(self, val):
+    def _not(self, val, query_env={}):
         op, f, s = val.op, val.first, val.second
         if op in [self._or, self._and]:
             not_op = self._and if op == self._or else self._or

--- a/pydal/dialects/ingres.py
+++ b/pydal/dialects/ingres.py
@@ -1,3 +1,4 @@
+from .._compat import basestring
 from ..adapters.ingres import Ingres, IngresUnicode
 from .base import SQLDialect
 from . import dialects, sqltype_for
@@ -67,7 +68,10 @@ class IngresDialect(SQLDialect):
             '(%(field_name)s) REFERENCES %(foreign_table)s' + \
             '(%(foreign_key)s) ON DELETE %(on_delete_action)s'
 
-    def left_join(self, val):
+    def left_join(self, val, query_env={}):
+        # Left join must always have an ON clause
+        if not isinstance(val, basestring):
+            val = self.expand(val, query_env=query_env)
         return 'LEFT OUTER JOIN %s' % val
 
     @property

--- a/pydal/dialects/mysql.py
+++ b/pydal/dialects/mysql.py
@@ -60,21 +60,25 @@ class MySQLDialect(SQLDialect):
     def random(self):
         return 'RAND()'
 
-    def substring(self, field, parameters):
+    def substring(self, field, parameters, query_env={}):
         return 'SUBSTRING(%s,%s,%s)' % (
-            self.expand(field), parameters[0], parameters[1])
+            self.expand(field, query_env=query_env), parameters[0],
+                parameters[1])
 
-    def epoch(self, first):
-        return "UNIX_TIMESTAMP(%s)" % self.expand(first)
+    def epoch(self, first, query_env={}):
+        return "UNIX_TIMESTAMP(%s)" % self.expand(first, query_env=query_env)
 
-    def concat(self, *items):
-        return 'CONCAT(%s)' % ','.join(self.expand(x, 'string') for x in items)
+    def concat(self, *items, **kwargs):
+        query_env = kwargs.get('query_env', {})
+        tmp = (self.expand(x, 'string', query_env=query_env) for x in items)
+        return 'CONCAT(%s)' % ','.join(tmp)
 
-    def regexp(self, first, second):
+    def regexp(self, first, second, query_env={}):
         return '(%s REGEXP %s)' % (
-            self.expand(first), self.expand(second, 'string'))
+            self.expand(first, query_env=query_env),
+            self.expand(second, 'string', query_env=query_env))
 
-    def cast(self, first, second):
+    def cast(self, first, second, query_env={}):
         if second == 'LONGTEXT':
             second = 'CHAR'
         return 'CAST(%s AS %s)' % (first, second)

--- a/pydal/dialects/oracle.py
+++ b/pydal/dialects/oracle.py
@@ -76,9 +76,10 @@ class OracleDialect(SQLDialect):
         return 'DEFAULT %s NOT NULL' % \
             self.adapter.represent(default, field_type)
 
-    def regexp(self, first, second):
+    def regexp(self, first, second, query_env={}):
         return 'REGEXP_LIKE(%s, %s)' % (
-            self.expand(first), self.expand(second, 'string'))
+            self.expand(first, query_env=query_env),
+            self.expand(second, 'string', query_env=query_env))
 
     def select(self, fields, tables, where=None, groupby=None, having=None,
                orderby=None, limitby=None, distinct=False, for_update=False):

--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -66,48 +66,51 @@ class PostgreDialect(SQLDialect):
     def random(self):
         return 'RANDOM()'
 
-    def add(self, first, second):
+    def add(self, first, second, query_env={}):
         t = first.type
         if t in ('text', 'string', 'password', 'json', 'upload', 'blob'):
             return '(%s || %s)' % (
-                self.expand(first), self.expand(second, first.type))
+                self.expand(first, query_env=query_env),
+                self.expand(second, first.type, query_env=query_env))
         else:
             return '(%s + %s)' % (
-                self.expand(first), self.expand(second, first.type))
+                self.expand(first, query_env=query_env),
+                self.expand(second, first.type, query_env=query_env))
 
-    def regexp(self, first, second):
+    def regexp(self, first, second, query_env={}):
         return '(%s ~ %s)' % (
-            self.expand(first), self.expand(second, 'string'))
+            self.expand(first, query_env=query_env),
+            self.expand(second, 'string', query_env=query_env))
 
-    def like(self, first, second, escape=None):
+    def like(self, first, second, escape=None, query_env={}):
         if isinstance(second, Expression):
-            second = self.expand(second, 'string')
+            second = self.expand(second, 'string', query_env=query_env)
         else:
-            second = self.expand(second, 'string')
+            second = self.expand(second, 'string', query_env=query_env)
             if escape is None:
                 escape = '\\'
                 second = second.replace(escape, escape * 2)
         if first.type not in ('string', 'text', 'json'):
             return "(%s LIKE %s ESCAPE '%s')" % (
-                self.cast(self.expand(first), 'CHAR(%s)' % first.length),
-                second, escape)
+                self.cast(self.expand(first, query_env=query_env),
+                'CHAR(%s)' % first.length), second, escape)
         return "(%s LIKE %s ESCAPE '%s')" % (
-            self.expand(first), second, escape)
+            self.expand(first, query_env=query_env), second, escape)
 
-    def ilike(self, first, second, escape=None):
+    def ilike(self, first, second, escape=None, query_env={}):
         if isinstance(second, Expression):
-            second = self.expand(second, 'string')
+            second = self.expand(second, 'string', query_env=query_env)
         else:
-            second = self.expand(second, 'string')
+            second = self.expand(second, 'string', query_env=query_env)
             if escape is None:
                 escape = '\\'
                 second = second.replace(escape, escape * 2)
         if first.type not in ('string', 'text', 'json', 'list:string'):
             return "(%s ILIKE %s ESCAPE '%s')" % (
-                self.cast(self.expand(first), 'CHAR(%s)' % first.length),
-                second, escape)
+                self.cast(self.expand(first, query_env=query_env),
+                'CHAR(%s)' % first.length), second, escape)
         return "(%s ILIKE %s ESCAPE '%s')" % (
-            self.expand(first), second, escape)
+            self.expand(first, query_env=query_env), second, escape)
 
     def drop_table(self, table, mode):
         if mode not in ['restrict', 'cascade', '']:
@@ -125,60 +128,70 @@ class PostgreDialect(SQLDialect):
                     self.expand(field) for field in expressions), whr)
         return rv
 
-    def st_asgeojson(self, first, second):
+    def st_asgeojson(self, first, second, query_env={}):
         return 'ST_AsGeoJSON(%s,%s,%s,%s)' % (
-            second['version'], self.expand(first), second['precision'],
-            second['options'])
+            second['version'], self.expand(first, query_env=query_env),
+            second['precision'], second['options'])
 
-    def st_astext(self, first):
-        return 'ST_AsText(%s)' % self.expand(first)
+    def st_astext(self, first, query_env={}):
+        return 'ST_AsText(%s)' % self.expand(first, query_env=query_env)
 
-    def st_x(self, first):
-        return 'ST_X(%s)' % (self.expand(first))
+    def st_x(self, first, query_env={}):
+        return 'ST_X(%s)' % (self.expand(first, query_env=query_env))
 
-    def st_y(self, first):
-        return 'ST_Y(%s)' % (self.expand(first))
+    def st_y(self, first, query_env={}):
+        return 'ST_Y(%s)' % (self.expand(first, query_env=query_env))
 
-    def st_contains(self, first, second):
+    def st_contains(self, first, second, query_env={}):
         return 'ST_Contains(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_distance(self, first, second):
+    def st_distance(self, first, second, query_env={}):
         return 'ST_Distance(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_equals(self, first, second):
+    def st_equals(self, first, second, query_env={}):
         return 'ST_Equals(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_intersects(self, first, second):
+    def st_intersects(self, first, second, query_env={}):
         return 'ST_Intersects(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_overlaps(self, first, second):
+    def st_overlaps(self, first, second, query_env={}):
         return 'ST_Overlaps(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_simplify(self, first, second):
+    def st_simplify(self, first, second, query_env={}):
         return 'ST_Simplify(%s,%s)' % (
-            self.expand(first), self.expand(second, 'double'))
+            self.expand(first, query_env=query_env),
+            self.expand(second, 'double', query_env=query_env))
 
-    def st_simplifypreservetopology(self, first, second):
+    def st_simplifypreservetopology(self, first, second, query_env={}):
         return 'ST_SimplifyPreserveTopology(%s,%s)' % (
-            self.expand(first), self.expand(second, 'double'))
+            self.expand(first, query_env=query_env),
+            self.expand(second, 'double', query_env=query_env))
 
-    def st_touches(self, first, second):
+    def st_touches(self, first, second, query_env={}):
         return 'ST_Touches(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_within(self, first, second):
+    def st_within(self, first, second, query_env={}):
         return 'ST_Within(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_dwithin(self, first, tup):
+    def st_dwithin(self, first, tup, query_env={}):
         return 'ST_DWithin(%s,%s,%s)' % (
-            self.expand(first), self.expand(tup[0], first.type),
-            self.expand(tup[1], 'double'))
+            self.expand(first, query_env=query_env),
+            self.expand(tup[0], first.type, query_env=query_env),
+            self.expand(tup[1], 'double', query_env=query_env))
 
     @register_expression('doy')
     def extract_doy(self, expr):
@@ -237,30 +250,31 @@ class PostgreDialectArrays(PostgreDialect):
     def type_list_reference(self):
         return 'BIGINT[]'
 
-    def any(self, val):
-        return "ANY(%s)" % self.expand(val)
+    def any(self, val, query_env={}):
+        return "ANY(%s)" % self.expand(val, query_env=query_env)
 
-    def contains(self, first, second, case_sensitive=True):
+    def contains(self, first, second, case_sensitive=True, query_env={}):
         if first.type.startswith('list:'):
-            f = self.expand(second, 'string')
-            s = self.any(first)
+            f = self.expand(second, 'string', query_env=query_env)
+            s = self.any(first, query_env)
             if case_sensitive is True:
                 return self.eq(f, s)
-            return self.ilike(f, s, escape='\\')
+            return self.ilike(f, s, escape='\\', query_env=query_env)
         return super(PostgreDialectArrays, self).contains(
-            first, second, case_sensitive=case_sensitive)
+            first, second, case_sensitive=case_sensitive, query_env=query_env)
 
-    def ilike(self, first, second, escape=None):
+    def ilike(self, first, second, escape=None, query_env={}):
         if first and 'type' not in first:
-            args = (first, self.expand(second))
+            args = (first, self.expand(second, query_env=query_env))
             return '(%s ILIKE %s)' % args
         return super(PostgreDialectArrays, self).ilike(
-            first, second, escape=escape)
+            first, second, escape=escape, query_env=query_env)
 
-    def EQ(self, first, second=None):
+    def EQ(self, first, second=None, query_env={}):
         if first and 'type' not in first:
-            return '(%s = %s)' % (first, self.expand(second))
-        return super(PostgreDialectArrays, self).eq(first, second)
+            return '(%s = %s)' % (first,
+                self.expand(second, query_env=query_env))
+        return super(PostgreDialectArrays, self).eq(first, second, query_env)
 
 
 class PostgreDialectArraysJSON(PostgreDialectArrays):

--- a/pydal/dialects/sqlite.py
+++ b/pydal/dialects/sqlite.py
@@ -21,12 +21,14 @@ class SQLiteDialect(SQLDialect):
     def type_decimal(self):
         return self.types['float']
 
-    def extract(self, field, what):
-        return "web2py_extract('%s', %s)" % (what, self.expand(field))
+    def extract(self, field, what, query_env={}):
+        return "web2py_extract('%s', %s)" % (what,
+            self.expand(field, query_env=query_env))
 
-    def regexp(self, first, second):
+    def regexp(self, first, second, query_env={}):
         return '(%s REGEXP %s)' % (
-            self.expand(first), self.expand(second, 'string'))
+            self.expand(first, query_env=query_env),
+            self.expand(second, 'string', query_env=query_env))
 
     def select(self, fields, tables, where=None, groupby=None, having=None,
                orderby=None, limitby=None, distinct=False, for_update=False):
@@ -50,41 +52,50 @@ class SpatialiteDialect(SQLiteDialect):
     def type_geometry(self):
         return 'GEOMETRY'
 
-    def st_asgeojson(self, first, second):
+    def st_asgeojson(self, first, second, query_env={}):
         return 'AsGeoJSON(%s,%s,%s)' % (
-            self.expand(first), second['precision'], second['options'])
+            self.expand(first, query_env=query_env), second['precision'],
+            second['options'])
 
-    def st_astext(self, first):
-        return 'AsText(%s)' % self.expand(first)
+    def st_astext(self, first, query_env={}):
+        return 'AsText(%s)' % self.expand(first, query_env=query_env)
 
-    def st_contains(self, first, second):
+    def st_contains(self, first, second, query_env={}):
         return 'Contains(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_distance(self, first, second):
+    def st_distance(self, first, second, query_env={}):
         return 'Distance(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_equals(self, first, second):
+    def st_equals(self, first, second, query_env={}):
         return 'Equals(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_intersects(self, first, second):
+    def st_intersects(self, first, second, query_env={}):
         return 'Intersects(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_overlaps(self, first, second):
+    def st_overlaps(self, first, second, query_env={}):
         return 'Overlaps(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_simplify(self, first, second):
+    def st_simplify(self, first, second, query_env={}):
         return 'Simplify(%s,%s)' % (
-            self.expand(first), self.expand(second, 'double'))
+            self.expand(first, query_env=query_env),
+            self.expand(second, 'double', query_env=query_env))
 
-    def st_touches(self, first, second):
+    def st_touches(self, first, second, query_env={}):
         return 'Touches(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))
 
-    def st_within(self, first, second):
+    def st_within(self, first, second, query_env={}):
         return 'Within(%s,%s)' % (
-            self.expand(first), self.expand(second, first.type))
+            self.expand(first, query_env=query_env),
+            self.expand(second, first.type, query_env=query_env))

--- a/pydal/dialects/teradata.py
+++ b/pydal/dialects/teradata.py
@@ -1,3 +1,4 @@
+from .._compat import basestring
 from ..adapters.teradata import Teradata
 from .base import SQLDialect
 from . import dialects, sqltype_for
@@ -66,7 +67,10 @@ class TeradataDialect(SQLDialect):
         return ' FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s' + \
             ' (%(foreign_key)s)'
 
-    def left_join(self, val):
+    def left_join(self, val, query_env={}):
+        # Left join must always have an ON clause
+        if not isinstance(val, basestring):
+            val = self.expand(val, query_env=query_env)
         return 'LEFT OUTER JOIN %s' % val
 
     def select(self, fields, tables, where=None, groupby=None, having=None,

--- a/pydal/helpers/methods.py
+++ b/pydal/helpers/methods.py
@@ -65,6 +65,25 @@ def use_common_filters(query):
             not query.ignore_common_filters)
 
 
+def merge_tablemaps(*maplist):
+    """Merge arguments into a single dict, check for name collisions.
+    Arguments may be modified in the process."""
+    ret = maplist[0]
+    for item in maplist[1:]:
+        if len(ret) > len(item):
+            big, small = ret, item
+        else:
+            big, small = item, ret
+        # Check for name collisions
+        for key, val in small.items():
+            if big.get(key, val) is not val:
+                raise ValueError('Name conflict in table list: %s' % key)
+        # Merge
+        big.update(small)
+        ret = big
+    return ret
+
+
 def bar_escape(item):
     return str(item).replace('|', '||')
 

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1153,7 +1153,7 @@ class Select(BasicStorage):
         return Expression(self._db, self._db._adapter.dialect.on, self, query)
 
     def _compile(self, outer_scoped=[], with_alias=False):
-        if not self._sql_cache:
+        if outer_scoped or not self._sql_cache:
             adapter = self._db._adapter
             attributes = self._attributes.copy()
             attributes['outer_scoped'] = outer_scoped

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2074,12 +2074,12 @@ class Set(Serializable):
 
     def _delete(self):
         db = self.db
-        tablename = db._adapter.get_table(self.query)
+        tablename = db._adapter.get_table(self.query)._tablename
         return db._adapter._delete(tablename, self.query)
 
     def _update(self, **update_fields):
         db = self.db
-        tablename = db._adapter.get_table(self.query)
+        tablename = db._adapter.get_table(self.query)._tablename
         fields = db[tablename]._listify(update_fields, update=True)
         return db._adapter._update(tablename, self.query, fields)
 
@@ -2222,7 +2222,7 @@ class Set(Serializable):
 
     def delete(self):
         db = self.db
-        tablename = db._adapter.get_table(self.query)
+        tablename = db._adapter.get_table(self.query)._tablename
         table = db[tablename]
         if any(f(self) for f in table._before_delete):
             return 0
@@ -2232,7 +2232,7 @@ class Set(Serializable):
 
     def update(self, **update_fields):
         db = self.db
-        tablename = db._adapter.get_table(self.query)
+        tablename = db._adapter.get_table(self.query)._tablename
         table = db[tablename]
         table._attempt_upload(update_fields)
         if any(f(self, update_fields) for f in table._before_update):
@@ -2248,7 +2248,7 @@ class Set(Serializable):
         """
         Same as update but does not call table._before_update and _after_update
         """
-        tablename = self.db._adapter.get_table(self.query)
+        tablename = self.db._adapter.get_table(self.query)._tablename
         table = self.db[tablename]
         fields = table._listify(update_fields, update=True)
         if not fields:
@@ -2258,7 +2258,7 @@ class Set(Serializable):
         return ret
 
     def validate_and_update(self, **update_fields):
-        tablename = self.db._adapter.get_table(self.query)
+        tablename = self.db._adapter.get_table(self.query)._tablename
         response = Row()
         response.errors = Row()
         new_fields = copy.copy(update_fields)

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2222,7 +2222,7 @@ class Set(Serializable):
                                     attributes.get('orderby', None),
                                     attributes.get('groupby', None))
         fields = adapter.expand_all(fields, tablenames)
-        return Select(self.db, self.query, fields, attributes)
+        return adapter.nested_select(self.query, fields, attributes)
 
     def delete(self):
         db = self.db

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2961,19 +2961,13 @@ class Rows(BasicRows):
                                representer in DAL instance")
         row = copy.deepcopy(self.records[i])
         keys = list(row.keys())
-        tables = [f.tablename for f in fields] if fields \
-            else [k for k in keys if k != '_extra']
-        for table in tables:
-            repr_fields = [f.name for f in fields if f.tablename == table] \
-                if fields else [
-                    k for k in row[table].keys()
-                    if (hasattr(self.db[table], k) and
-                        isinstance(self.db[table][k], Field) and
-                        self.db[table][k].represent)]
-            for field in repr_fields:
-                row[table][field] = self.db.represent(
-                    'rows_render', self.db[table][field], row[table][field],
-                    row[table])
+        if not fields:
+            fields = [f for f in self.fields
+                    if isinstance(f, Field) and f.represent]
+        for field in fields:
+            row[field._tablename][field.name] = self.db.represent(
+                'rows_render', field, row[field._tablename][field.name],
+                row[field._tablename])
 
         if self.compact and len(keys) == 1 and keys[0] != '_extra':
             return row[keys[0]]

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -612,11 +612,7 @@ class Table(Serializable, BasicStorage):
 
     def __str__(self):
         if self._ot is not None:
-            ot = self._ot
-            if 'Oracle' in str(type(self._db._adapter)):
-                return '%s %s' % (ot, self._tablename)
-            return '%s AS %s' % (ot, self._tablename)
-
+            return self._db._adapter.dialect._as(self._ot, self._tablename)
         return self._tablename
 
     @property
@@ -1169,11 +1165,8 @@ class Select(BasicStorage):
         else:
             colnames, sql = self._colnames_cache, self._sql_cache
         if with_alias and self._tablename is not None:
-            alias = self._db._adapter.dialect.quote(self._tablename)
-            if 'Oracle' in str(type(self._db._adapter)):
-                sql = '(%s) %s' % (sql[:-1], alias)
-            else:
-                sql = '(%s) AS %s' % (sql[:-1], alias)
+            sql = '(%s)' % sql[:-1]
+            sql = self._db._adapter.dialect.alias(sql, self._tablename)
         return colnames, sql
 
     def query_name(self, outer_scoped=[]):

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1059,6 +1059,8 @@ class Select(BasicStorage):
         self._tablename = None # alias will be stored here
         self._common_filter = None
         self._query = query
+        # if false, the subquery will never reference tables from parent scope
+        self._correlated = attributes.pop('correlated', True)
         self._attributes = attributes
         self._qfields = list(fields)
         self._fields = SQLCallableList()
@@ -1153,6 +1155,8 @@ class Select(BasicStorage):
         return Expression(self._db, self._db._adapter.dialect.on, self, query)
 
     def _compile(self, outer_scoped=[], with_alias=False):
+        if not self._correlated:
+            outer_scoped = []
         if outer_scoped or not self._sql_cache:
             adapter = self._db._adapter
             attributes = self._attributes.copy()

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2202,7 +2202,14 @@ class Set(Serializable):
         return adapter.iterselect(self.query, fields, attributes)
 
     def nested_select(self, *fields, **attributes):
-        return Expression(self.db, self._select(*fields, **attributes))
+        adapter = self.db._adapter
+        tablenames = adapter.tables(self.query,
+                                    attributes.get('join', None),
+                                    attributes.get('left', None),
+                                    attributes.get('orderby', None),
+                                    attributes.get('groupby', None))
+        fields = adapter.expand_all(fields, tablenames)
+        return Select(self.db, self.query, fields, attributes)
 
     def delete(self):
         db = self.db

--- a/tests/nosql.py
+++ b/tests/nosql.py
@@ -184,11 +184,11 @@ class TestMongo(unittest.TestCase):
             db.define_table('tt', Field('aa'))
             self.assertEqual(isinstance(db.tt.insert(aa='x'), long), True)
             with self.assertRaises(RuntimeError):
-                db._adapter.delete('tt', 'x', safe=safe)
+                db._adapter.delete(db['tt'], 'x', safe=safe)
             self.assertEqual(db._adapter.delete(
-                'tt', Query(db, db._adapter.dialect.eq, db.tt.aa, 'x'), safe=safe), 1)
+                db['tt'], Query(db, db._adapter.dialect.eq, db.tt.aa, 'x'), safe=safe), 1)
             self.assertEqual(db(db.tt.aa=='x').count(), 0)
-            self.assertEqual(db._adapter.update('tt',
+            self.assertEqual(db._adapter.update(db['tt'],
                     Query(db, db._adapter.dialect.eq, db.tt.aa, 'x'),
                     db['tt']._listify({'aa':'x'}), safe=safe), 0)
             drop(db.tt)

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -13,7 +13,7 @@ import json
 from pydal._compat import PY2, basestring, StringIO, integer_types, xrange
 from pydal import DAL, Field
 from pydal.helpers.classes import SQLALL
-from pydal.objects import Table
+from pydal.objects import Table, Expression
 from ._compat import unittest
 from ._adapt import (
     DEFAULT_URI, IS_POSTGRESQL, IS_SQLITE, IS_MSSQL, IS_MYSQL, IS_TERADATA, _quote)
@@ -613,6 +613,211 @@ class TestSelect(DALtest):
         self.assertEqual(result.response[0][0], 0)
         self.assertEqual(result.response[1][0], 1)
 
+
+class TestSubselect(DALtest):
+
+    def testMethods(self):
+        db = self.connect()
+        db.define_table('tt', Field('aa', 'integer'), Field('bb'))
+        data = [
+            dict(aa=1, bb='foo'), dict(aa=1, bb='bar'), dict(aa=2, bb='foo')
+        ]
+        for item in data:
+            db.tt.insert(**item)
+        fields = [db.tt.aa, db.tt.bb, db.tt.aa+2,
+            (db.tt.aa+1).with_alias('exp')]
+        sub = db(db.tt).nested_select(*fields, orderby=db.tt.id)
+        # Check the fields provided by the object
+        self.assertEqual(sorted(['aa', 'bb', 'exp']), sorted(list(sub.fields)))
+        for name in sub.fields:
+            self.assertIsInstance(sub[name], Field)
+        for item in sub:
+            self.assertIsInstance(item, Field)
+        self.assertEqual(len(list(sub)), len(sub.fields))
+        for key, val in zip(sub.fields, sub):
+            self.assertIs(sub[key], val)
+            self.assertIs(getattr(sub, key), val)
+        tmp = sub._filter_fields(dict(aa=1, exp=2, foo=3))
+        self.assertEqual(tmp, dict(aa=1, exp=2))
+        # Check result from executing the query
+        result = sub()
+        self.assertEqual(len(result), len(data))
+        for idx, row in enumerate(data):
+            self.assertEqual(result[idx]['tt'].as_dict(), row)
+            self.assertEqual(result[idx]['exp'], row['aa']+1)
+        result = db.executesql(str(sub))
+        for idx, row in enumerate(data):
+            tmp = [row['aa'], row['bb'], row['aa']+2, row['aa']+1]
+            self.assertEqual(list(result[idx]), tmp)
+        # Check that query expansion methods don't work without alias
+        self.assertEqual(sub.real_name, None)
+        with self.assertRaises(SyntaxError):
+            sub.query_name()
+        with self.assertRaises(SyntaxError):
+            sub.query_alias
+        with self.assertRaises(SyntaxError):
+            sub.on(sub.aa != None)
+        # Alias checks
+        sub = sub.with_alias('foo')
+        result = sub()
+        for idx, row in enumerate(data):
+            self.assertEqual(result[idx]['tt'].as_dict(), row)
+            self.assertEqual(result[idx]['exp'], row['aa']+1)
+        # Check query expansion methods again
+        self.assertEqual(sub.real_name, None)
+        self.assertEqual(sub.query_name()[0], str(sub))
+        self.assertEqual(sub.query_alias, db._adapter.dialect.quote('foo'))
+        self.assertIsInstance(sub.on(sub.aa != None), Expression)
+
+    def testSelectArguments(self):
+        db = self.connect()
+        db.define_table('tt', Field('aa', 'integer'), Field('bb'))
+        data = [
+            dict(aa=1, bb='foo'), dict(aa=1, bb='bar'), dict(aa=2, bb='foo'),
+            dict(aa=3, bb='foo'), dict(aa=3, bb='baz')
+        ]
+        expected = [(1, None, 0), (2, 2, 2), (2, 2, 2), (3, 4, 3), (3, 8, 6)]
+        for item in data:
+            db.tt.insert(**item)
+
+        # Check that select clauses work as expected in stand-alone query
+        t1 = db.tt.with_alias('t1')
+        t2 = db.tt.with_alias('t2')
+        fields = [t1.aa, t2.aa.sum().with_alias('total'),
+            t2.aa.count().with_alias('cnt')]
+        join = t1.on(db.tt.bb != t1.bb)
+        left = t2.on(t1.aa > t2.aa)
+        group = db.tt.bb | t1.aa
+        having = db.tt.aa.count() > 1
+        order = t1.aa | t2.aa.count()
+        limit = (1,6)
+        sub = db(db.tt.aa != 2).nested_select(*fields, join=join, left=left,
+            orderby=order, groupby=group, having=having, limitby=limit)
+        result = sub()
+        self.assertEqual(len(result), len(expected))
+        for idx, val in enumerate(expected):
+            self.assertEqual(result[idx]['t1']['aa'], val[0])
+            self.assertEqual(result[idx]['total'], val[1])
+            self.assertEqual(result[idx]['cnt'], val[2])
+
+        # Check again when nested inside another query
+        # Also check that the alias will not conflict with existing table
+        t3 = db.tt.with_alias('t3')
+        sub = sub.with_alias('tt')
+        query = (t3.bb == 'foo') & (t3.aa == sub.aa)
+        order = t3.aa | sub.cnt
+        result = db(query).select(t3.aa, sub.total, sub.cnt, orderby=order)
+        for idx, val in enumerate(expected):
+            self.assertEqual(result[idx]['t3']['aa'], val[0])
+            self.assertEqual(result[idx]['tt']['total'], val[1])
+            self.assertEqual(result[idx]['tt']['cnt'], val[2])
+
+        # Check "distinct" modifier separately
+        sub = db(db.tt.aa != 2).nested_select(db.tt.aa, distinct=True)
+        result = sub().as_list()
+        self.assertEqual(result, [dict(aa=1), dict(aa=3)])
+
+    def testCorrelated(self):
+        db = self.connect()
+        db.define_table('t1', Field('aa', 'integer'), Field('bb'))
+        db.define_table('t2', Field('aa', 'integer'), Field('cc'))
+        db.define_table('t3', Field('aa', 'integer'))
+        data_t1 = [
+            dict(aa=1, bb='bar'), dict(aa=1, bb='foo'), dict(aa=2, bb='foo'),
+            dict(aa=2, bb='test'), dict(aa=3, bb='baz'), dict(aa=3, bb='foo')
+        ]
+        data_t2 = [
+            dict(aa=1, cc='foo'), dict(aa=2, cc='bar'), dict(aa=3, cc='baz')
+        ]
+        expected_cor = [(1, 'foo'), (3, 'baz')]
+        expected_leftcor = [(1, 'foo'), (2, None), (3, 'baz')]
+        expected_uncor = [
+            (1, 'bar'), (1, 'foo'), (2, 'foo'), (3, 'baz'), (3, 'foo')
+        ]
+        for item in data_t1:
+            db.t1.insert(**item)
+        for item in data_t2:
+            db.t2.insert(**item)
+            db.t3.insert(aa=item['aa'])
+
+        # Correlated subqueries
+        subquery = db.t1.aa == db.t2.aa
+        subfields = [db.t2.cc]
+        sub = db(subquery).nested_select(*subfields).with_alias('sub')
+        query = db.t1.bb.belongs(sub)
+        order = db.t1.aa | db.t1.bb
+        result = db(query).select(db.t1.aa, db.t1.bb, orderby=order)
+        self.assertEqual(len(result), len(expected_cor))
+        for idx, val in enumerate(expected_cor):
+            self.assertEqual(result[idx]['aa'], val[0])
+            self.assertEqual(result[idx]['bb'], val[1])
+
+        join = [db.t1.on((db.t3.aa == db.t1.aa) & db.t1.bb.belongs(sub))]
+        order = db.t3.aa | db.t1.bb
+        result = db(db.t3).select(db.t3.aa, db.t1.bb, join=join, orderby=order)
+        self.assertEqual(len(result), len(expected_cor))
+        for idx, val in enumerate(expected_cor):
+            self.assertEqual(result[idx]['t3']['aa'], val[0])
+            self.assertEqual(result[idx]['t1']['bb'], val[1])
+
+        left = [db.t1.on((db.t3.aa == db.t1.aa) & db.t1.bb.belongs(sub))]
+        result = db(db.t3).select(db.t3.aa, db.t1.bb, left=left, orderby=order)
+        self.assertEqual(len(result), len(expected_leftcor))
+        for idx, val in enumerate(expected_leftcor):
+            self.assertEqual(result[idx]['t3']['aa'], val[0])
+            self.assertEqual(result[idx]['t1']['bb'], val[1])
+
+        # Uncorrelated subqueries
+        kwargs = dict(correlated=False)
+        sub = db(subquery).nested_select(*subfields, **kwargs)
+        query = db.t1.bb.belongs(sub)
+        order = db.t1.aa | db.t1.bb
+        result = db(query).select(db.t1.aa, db.t1.bb, orderby=order)
+        self.assertEqual(len(result), len(expected_uncor))
+        for idx, val in enumerate(expected_uncor):
+            self.assertEqual(result[idx]['aa'], val[0])
+            self.assertEqual(result[idx]['bb'], val[1])
+
+        join = [db.t1.on((db.t3.aa == db.t1.aa) & db.t1.bb.belongs(sub))]
+        order = db.t3.aa | db.t1.bb
+        result = db(db.t3).select(db.t3.aa, db.t1.bb, join=join, orderby=order)
+        self.assertEqual(len(result), len(expected_uncor))
+        for idx, val in enumerate(expected_uncor):
+            self.assertEqual(result[idx]['t3']['aa'], val[0])
+            self.assertEqual(result[idx]['t1']['bb'], val[1])
+
+        left = [db.t1.on((db.t3.aa == db.t1.aa) & db.t1.bb.belongs(sub))]
+        result = db(db.t3).select(db.t3.aa, db.t1.bb, left=left, orderby=order)
+        self.assertEqual(len(result), len(expected_uncor))
+        for idx, val in enumerate(expected_uncor):
+            self.assertEqual(result[idx]['t3']['aa'], val[0])
+            self.assertEqual(result[idx]['t1']['bb'], val[1])
+
+        # Correlation prevented by alias in parent select
+        tmp = db.t1.with_alias('tmp')
+        sub = db(subquery).nested_select(*subfields)
+        query = tmp.bb.belongs(sub)
+        order = tmp.aa | tmp.bb
+        result = db(query).select(tmp.aa, tmp.bb, orderby=order)
+        self.assertEqual(len(result), len(expected_uncor))
+        for idx, val in enumerate(expected_uncor):
+            self.assertEqual(result[idx]['aa'], val[0])
+            self.assertEqual(result[idx]['bb'], val[1])
+
+        join = [tmp.on((db.t3.aa == tmp.aa) & tmp.bb.belongs(sub))]
+        order = db.t3.aa | tmp.bb
+        result = db(db.t3).select(db.t3.aa, tmp.bb, join=join, orderby=order)
+        self.assertEqual(len(result), len(expected_uncor))
+        for idx, val in enumerate(expected_uncor):
+            self.assertEqual(result[idx]['t3']['aa'], val[0])
+            self.assertEqual(result[idx]['tmp']['bb'], val[1])
+
+        left = [tmp.on((db.t3.aa == tmp.aa) & tmp.bb.belongs(sub))]
+        result = db(db.t3).select(db.t3.aa, tmp.bb, left=left, orderby=order)
+        self.assertEqual(len(result), len(expected_uncor))
+        for idx, val in enumerate(expected_uncor):
+            self.assertEqual(result[idx]['t3']['aa'], val[0])
+            self.assertEqual(result[idx]['tmp']['bb'], val[1])
 
 class TestAddMethod(DALtest):
 


### PR DESCRIPTION
This changeset implements subselect objects that can be used in a join like a virtual table or passed to `Expression.belongs()`. Subselect objects can be created using `Set.nested_select()` which accepts the same arguments as regular `select()`. One additional argument, `correlated`, determines whether the subselect may reference tables from parent select (defaults to `True` which means referencing is permitted). Example usage:

    total = table1.field2.sum().with_alias('total')
    sub1 = db(table1.field2 != None).nested_select(table1.field1, total, groupby=table1.field1)
    sub1 = sub1.with_alias('tmp')
    result1 = db(table2.field1 == sub1.field1).select(table2.ALL, sub1.total)

    total = table1.field2.sum().with_alias('total')
    sub2 = db(table1.field2 != None).nested_select(total, groupby=table1.field1)
    result2 = db(table2.field2.belongs(sub2)).select(table2.ALL)

----

I'm opening this pull request early for design discussion. Unit tests for Python 2.7, 3.4 & 3.5 and SQLite, MySQL and PostgreSQL are passing on my machine but there's still work to do. Comments and suggestions are appreciated.
## Design changes
- Adapters and dialects must no longer resolve table names over and over through `DAL.__getitem__()`. They must pass Table/Select objects around.
- New methods for class `Table`:
  - `query_name()` - Full table name for query FROM clause, including possible alias.
  - `query_alias()` - The appropriate string that identifies the table throughout a query (e.g. for building fully qualified field names).
- `Rows.__init__()` now takes additional argument - list of `Field`/`Expression` objects corresponding to columns
- `BaseAdapter._select()` now returns a `Select` object instead of string
- `BaseAdapter.tables()` now returns a dict mapping table names to table objects instead of name list.
- `BaseAdapter.common_filter()` now accepts table objects as well as table names.
- many other `BaseAdapter` internal methods now take or return table objects instead of table names.