### PR TITLE
Postgres fixes

### DIFF
--- a/pydal/adapters/postgres.py
+++ b/pydal/adapters/postgres.py
@@ -8,7 +8,7 @@ from . import AdapterMeta, adapters, with_connection, with_connection_or_raise
 
 class PostgreMeta(AdapterMeta):
     def __call__(cls, *args, **kwargs):
-        if cls != Postgre:
+        if cls not in [Postgre, PostgreNew, PostgreBoolean]:
             return AdapterMeta.__call__(cls, *args, **kwargs)
         available_drivers = [
             driver for driver in cls.drivers
@@ -20,10 +20,7 @@ class PostgreMeta(AdapterMeta):
         else:
             driver = available_drivers[0] if available_drivers else \
                 cls.drivers[0]
-        if driver == 'psycopg2':
-            cls = PostgrePsyco
-        else:
-            cls = PostgrePG8000
+        cls = adapters._registry_[uri_items[0] + ":" + driver]
         return AdapterMeta.__call__(cls, *args, **kwargs)
 
 
@@ -197,12 +194,12 @@ class PostgreNew(Postgre):
 
 
 @adapters.register_for('postgres2:psycopg2')
-class PostgrePsycoNew(PostgrePsyco):
+class PostgrePsycoNew(PostgrePsyco, PostgreNew):
     pass
 
 
 @adapters.register_for('postgres2:pg8000')
-class PostgrePG8000New(PostgrePG8000):
+class PostgrePG8000New(PostgrePG8000, PostgreNew):
     pass
 
 
@@ -218,12 +215,12 @@ class PostgreBoolean(PostgreNew):
 
 
 @adapters.register_for('postgres3:psycopg2')
-class PostgrePsycoBoolean(PostgrePsycoNew):
+class PostgrePsycoBoolean(PostgrePsycoNew, PostgreBoolean):
     pass
 
 
 @adapters.register_for('postgres3:pg8000')
-class PostgrePG8000Boolean(PostgrePG8000New):
+class PostgrePG8000Boolean(PostgrePG8000New, PostgreBoolean):
     pass
 
 

--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -257,7 +257,7 @@ class PostgreDialectArrays(PostgreDialect):
         return super(PostgreDialectArrays, self).ilike(
             first, second, escape=escape)
 
-    def EQ(self, first, second=None):
+    def eq(self, first, second=None):
         if first and 'type' not in first:
             return '(%s = %s)' % (first, self.expand(second))
         return super(PostgreDialectArrays, self).eq(first, second)

--- a/pydal/representers/base.py
+++ b/pydal/representers/base.py
@@ -66,11 +66,14 @@ class BaseRepresenter(Representer):
             value = [value]
         return value
 
+    def _listify_elements(self, elements):
+        return bar_encode(elements)
+
     @for_type('list:integer')
     def _list_integer(self, value):
         values = self._ensure_list(value)
         values = list(map(int, [val for val in values if val != '']))
-        return bar_encode(value)
+        return self._listify_elements(value)
 
     @for_type('list:string')
     def _list_string(self, value):
@@ -83,7 +86,7 @@ class BaseRepresenter(Representer):
                     lambda x: unicode(x).encode(self.adapter.db_codec), value)
         else:
             value = list(map(str, value))
-        return bar_encode(value)
+        return self._listify_elements(value)
 
     @for_type('list:reference', adapt=False)
     def _list_reference(self, value):

--- a/pydal/representers/postgre.py
+++ b/pydal/representers/postgre.py
@@ -33,4 +33,4 @@ class PostgreRepresenter(SQLRepresenter, JSONRepresenter):
 @representers.register_for(PostgreNew)
 class PostgreArraysRepresenter(PostgreRepresenter):
     def _listify_elements(self, elements):
-        return "{" + ",".join(elements) + "}"
+        return "{" + ",".join(str(el) for el in elements) + "}"

--- a/pydal/representers/postgre.py
+++ b/pydal/representers/postgre.py
@@ -1,4 +1,4 @@
-from ..adapters.postgres import Postgre
+from ..adapters.postgres import Postgre, PostgreNew
 from .base import SQLRepresenter, JSONRepresenter
 from . import representers, before_type, for_type
 
@@ -28,3 +28,9 @@ class PostgreRepresenter(SQLRepresenter, JSONRepresenter):
     @for_type('geography', adapt=False)
     def _geography(self, value, srid):
         return "ST_GeogFromText('SRID=%s;%s')" % (srid, value)
+
+
+@representers.register_for(PostgreNew)
+class PostgreArraysRepresenter(PostgreRepresenter):
+    def _listify_elements(self, elements):
+        return "{" + ",".join(elements) + "}"


### PR DESCRIPTION
This fixes several bugs with postgres adapters, in particular:

i) Wrong adapter class when using `postgres2` or `postgres3` uri without specifying the driver
ii) Wrong dialect and parser classes on `postgres2` and `postgres3` adapters. This is before the fix:

```python
>>> db._adapter
<pydal.adapters.postgres.PostgrePsycoBoolean object at 0x7fecdd7e2850>
>>> db._adapter.dialect
<pydal.dialects.postgre.PostgreDialectJSON object at 0x7fecdd7442d0>
>>> db._adapter.representer
<pydal.representers.postgre.PostgreRepresenter object at 0x7fecdd73ad90>
>>> db._adapter.parser
<pydal.parsers.postgre.PostgreAutoJSONParser object at 0x7fecdd73aa10>
```

and after:

```python
>>> db._adapter
<pydal.adapters.postgres.PostgrePsycoBoolean object at 0x7fecdd7e2850>
>>> db._adapter.dialect
<pydal.dialects.postgre.PostgreDialectBooleanJSON object at 0x7ff4bb62e190>
>>> db._adapter.representer
<pydal.representers.postgre.PostgreArraysRepresenter object at 0x7ff4bb624c50>
>>> db._adapter.parser
<pydal.parsers.postgre.PostgreBooleanAutoJSONParser object at 0x7ff4bb624b50>
```

iii) Wrong representation of *list* fields with `postgres2` and `postgres3` that need `{val1,val2}` instead of `|val1|val2|`