### PR TITLE
fix issue where Set.delete_uploaded_files removes files it should not…

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2141,24 +2141,23 @@ class Set(Serializable):
                 oldname = record.get(fieldname, None)
                 if not oldname:
                     continue
-                if upload_fields and fieldname in upload_fields and \
-                   oldname == upload_fields[fieldname]:
-                    continue
-                if field.custom_delete:
-                    field.custom_delete(oldname)
-                else:
-                    uploadfolder = field.uploadfolder
-                    if not uploadfolder:
-                        uploadfolder = pjoin(
-                            self.db._adapter.folder, '..', 'uploads')
-                    if field.uploadseparate:
-                        items = oldname.split('.')
-                        uploadfolder = pjoin(
-                            uploadfolder, "%s.%s" %
-                            (items[0], items[1]), items[2][:2])
-                    oldpath = pjoin(uploadfolder, oldname)
-                    if exists(oldpath):
-                        os.unlink(oldpath)
+                if upload_fields is None or (fieldname in upload_fields and
+                                            oldname != upload_fields[fieldname]):
+                    if field.custom_delete:
+                        field.custom_delete(oldname)
+                    else:
+                        uploadfolder = field.uploadfolder
+                        if not uploadfolder:
+                            uploadfolder = pjoin(
+                                self.db._adapter.folder, '..', 'uploads')
+                        if field.uploadseparate:
+                            items = oldname.split('.')
+                            uploadfolder = pjoin(
+                                uploadfolder, "%s.%s" %
+                                (items[0], items[1]), items[2][:2])
+                        oldpath = pjoin(uploadfolder, oldname)
+                        if exists(oldpath):
+                            os.unlink(oldpath)
         return False
 
 

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2127,7 +2127,14 @@ class Set(Serializable):
         if upload_fields:
             fields = list(upload_fields)
             # Explicitly add compute upload fields (ex: thumbnail)
-            fields += [f for f in table.fields if table[f].compute is not None]
+            computed_fields = [f for f in table.fields if table[f].compute is not None]
+            fields += computed_fields
+            row = Row(upload_fields)
+            for f in computed_fields:
+                try:
+                    upload_fields[f] = table[f].compute(row)
+                except:
+                    pass
         else:
             fields = table.fields
         fields = [f for f in fields if table[f].type == 'upload' and


### PR DESCRIPTION
… during an update

The change I made differentiates between updates and deletes by taking advantage of upload_fields always being None in the case of deletes. If it is an update it only deletes the file if the field with it was updated and the new value is different.

See:
https://groups.google.com/forum/#!topic/web2py-developers/gwEr1cHQNAY