### PR TITLE
Store values for callbacks on insert/update/delete operations

### DIFF
--- a/pydal/helpers/classes.py
+++ b/pydal/helpers/classes.py
@@ -5,13 +5,26 @@ import struct
 import time
 import traceback
 
-from .._compat import PY2, exists, copyreg, integer_types, implements_bool, \
-    iterkeys, itervalues, iteritems
+from .._compat import (
+    PY2, exists, copyreg, implements_bool, iterkeys, itervalues, iteritems,
+    long
+)
 from .._globals import THREAD_LOCAL
 from .serializers import serializers
 
 
-long = integer_types[-1]
+class cachedprop(object):
+    #: a read-only @property that is only evaluated once.
+    def __init__(self, fget, doc=None):
+        self.fget = fget
+        self.__doc__ = doc or fget.__doc__
+        self.__name__ = fget.__name__
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+        obj.__dict__[self.__name__] = result = self.fget(obj)
+        return result
 
 
 @implements_bool

--- a/pydal/helpers/classes.py
+++ b/pydal/helpers/classes.py
@@ -91,6 +91,77 @@ def pickle_basicstorage(s):
 copyreg.pickle(BasicStorage, pickle_basicstorage)
 
 
+class OpRow(object):
+    __slots__ = ('_table', '_fields', '_values')
+
+    def __init__(self, table):
+        object.__setattr__(self, '_table', table)
+        object.__setattr__(self, '_fields', {})
+        object.__setattr__(self, '_values', {})
+
+    def set_value(self, key, value, field=None):
+        self._values[key] = value
+        self._fields[key] = self._fields.get(key, field or self._table[key])
+
+    def del_value(self, key):
+        del self._values[key]
+        del self._fields[key]
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def __setitem__(self, key, value):
+        return self.set_value(key, value)
+
+    def __delitem__(self, key):
+        return self.del_value(key)
+
+    def __getattr__(self, key):
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            raise AttributeError
+
+    def __setattr__(self, key, value):
+        return self.set_value(key, value)
+
+    def __delattr__(self, key):
+        return self.del_value(key)
+
+    def __iter__(self):
+        return self._values.__iter__()
+
+    def __contains__(self, key):
+        return key in self._values
+
+    def keys(self):
+        return self._values.keys()
+
+    def iterkeys(self):
+        return iterkeys(self._values)
+
+    def values(self):
+        return self._values.values()
+
+    def itervalues(self):
+        return itervalues(self._values)
+
+    def items(self):
+        return self._values.items()
+
+    def iteritems(self):
+        return iteritems(self._values)
+
+    def op_values(self):
+        return [
+            (self._fields[key], value)
+            for key, value in iteritems(self._values)
+        ]
+
+    def __repr__(self):
+        return '<OpRow %s>' % repr(self._values)
+
+
 class Serializable(object):
     def as_dict(self, flat=False, sanitize=True):
         return self.__dict__

--- a/tests/nosql.py
+++ b/tests/nosql.py
@@ -15,7 +15,7 @@ from pydal._compat import PY2, basestring, StringIO, integer_types, to_bytes
 long = integer_types[-1]
 
 from pydal import DAL, Field
-from pydal.objects import Table, Query, Expression
+from pydal.objects import Table, Query, Expression, Row
 from pydal.helpers.classes import SQLALL
 from pydal.exceptions import NotOnNOSQLError
 from ._adapt import DEFAULT_URI, IS_IMAP, drop, IS_GAE, IS_MONGODB, _quote
@@ -188,9 +188,13 @@ class TestMongo(unittest.TestCase):
             self.assertEqual(db._adapter.delete(
                 db['tt'], Query(db, db._adapter.dialect.eq, db.tt.aa, 'x'), safe=safe), 1)
             self.assertEqual(db(db.tt.aa=='x').count(), 0)
-            self.assertEqual(db._adapter.update(db['tt'],
+            self.assertEqual(
+                db._adapter.update(
+                    db['tt'],
                     Query(db, db._adapter.dialect.eq, db.tt.aa, 'x'),
-                    db['tt']._listify({'aa':'x'}), safe=safe), 0)
+                    db['tt']._fields_and_values_for_update({'aa':'x'})[1],
+                    safe=safe
+                ), 0)
             drop(db.tt)
             db.close()
 
@@ -2292,7 +2296,7 @@ class TestBulkInsert(unittest.TestCase):
         global ctr
         ctr = 0
         def test_after_insert(i, r):
-            self.assertIsInstance(i, dict)
+            self.assertIsInstance(i, Row)
             global ctr
             ctr += 1
             return True

--- a/tests/nosql.py
+++ b/tests/nosql.py
@@ -10,13 +10,10 @@ import glob
 import datetime
 from ._compat import unittest
 
-from pydal._compat import PY2, basestring, StringIO, integer_types, to_bytes
-
-long = integer_types[-1]
-
+from pydal._compat import PY2, basestring, StringIO, to_bytes, long
 from pydal import DAL, Field
-from pydal.objects import Table, Query, Expression, Row
-from pydal.helpers.classes import SQLALL
+from pydal.objects import Table, Query, Expression
+from pydal.helpers.classes import SQLALL, OpRow
 from pydal.exceptions import NotOnNOSQLError
 from ._adapt import DEFAULT_URI, IS_IMAP, drop, IS_GAE, IS_MONGODB, _quote
 
@@ -192,7 +189,8 @@ class TestMongo(unittest.TestCase):
                 db._adapter.update(
                     db['tt'],
                     Query(db, db._adapter.dialect.eq, db.tt.aa, 'x'),
-                    db['tt']._fields_and_values_for_update({'aa':'x'})[1],
+                    db['tt']._fields_and_values_for_update(
+                        {'aa':'x'}).op_values(),
                     safe=safe
                 ), 0)
             drop(db.tt)
@@ -2296,7 +2294,7 @@ class TestBulkInsert(unittest.TestCase):
         global ctr
         ctr = 0
         def test_after_insert(i, r):
-            self.assertIsInstance(i, Row)
+            self.assertIsInstance(i, OpRow)
             global ctr
             ctr += 1
             return True

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -880,7 +880,7 @@ class TestAddMethod(DALtest):
             self.assertEqual(db.tt.insert(aa='1'), 3)
         else:
             self.assertEqual(db.tt.insert(aa='1'), 1)
-            self.assertEqual(db.tt.insert(aa='1'), 1)            
+            self.assertEqual(db.tt.insert(aa='1'), 1)
         self.assertEqual(len(db.tt.all()), 3)
 
 
@@ -895,7 +895,7 @@ class TestBelongs(DALtest):
             self.assertEqual(db.tt.insert(aa='3'), 3)
         else:
             self.assertEqual(db.tt.insert(aa='2'), 1)
-            self.assertEqual(db.tt.insert(aa='3'), 1)   
+            self.assertEqual(db.tt.insert(aa='3'), 1)
         self.assertEqual(db(db.tt.aa.belongs(('1', '3'))).count(),
                          2)
         self.assertEqual(db(db.tt.aa.belongs(db(db.tt.id
@@ -2593,7 +2593,7 @@ class TestBulkInsert(DALtest):
         global ctr
         ctr = 0
         def test_after_insert(i, r):
-            self.assertIsInstance(i, dict)
+            self.assertIsInstance(i, Row)
             global ctr
             ctr += 1
             return True

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -4,19 +4,19 @@
 """
 
 from __future__ import print_function
-import sys
 import os
 import glob
 import datetime
 import json
 
-from pydal._compat import PY2, basestring, StringIO, integer_types, xrange
+from pydal._compat import basestring, StringIO, integer_types, xrange
 from pydal import DAL, Field
-from pydal.helpers.classes import SQLALL
+from pydal.helpers.classes import SQLALL, OpRow
 from pydal.objects import Table, Expression, Row
 from ._compat import unittest
 from ._adapt import (
-    DEFAULT_URI, IS_POSTGRESQL, IS_SQLITE, IS_MSSQL, IS_MYSQL, IS_TERADATA, _quote)
+    DEFAULT_URI, IS_POSTGRESQL, IS_SQLITE, IS_MSSQL, IS_MYSQL, IS_TERADATA,
+    _quote)
 from ._helpers import DALtest
 
 long = integer_types[-1]
@@ -2593,7 +2593,7 @@ class TestBulkInsert(DALtest):
         global ctr
         ctr = 0
         def test_after_insert(i, r):
-            self.assertIsInstance(i, Row)
+            self.assertIsInstance(i, OpRow)
             global ctr
             ctr += 1
             return True


### PR DESCRIPTION
Ok everybody, this replace the current behaviour of `Table._listify`:
- all the values computed before callbacks are passed to callbacks
- removed duplicated logic for default fields: removed `_defaults` method
- all the fields that have callable values are computed in the same flow (defaults, updates, computations)

Rationale:
- Fixing computed fields flow (see #429 )
- Allow to use computed fields inside callbacks (see https://github.com/gi0baro/weppy/issues/151 and #429)
- Have a unique flow for callable values

Breaking change:
- If you accessed a callable default or update value in callbacks you had to invoke that within the callback to get the real value. Now is just the real value. 

Even if this is a breaking change, I consider the old behaviour *wrong*, since, for example, if you had a *created\_at* field with `default=lambda: datetime.utcnow()`, and in an *after_insert* callback you wanted to access that value in the fields, you simply couldn't, since the real value inserted calling the method is not stored in the flow.

I would like to hear @mdipierro, @niphlod, @leonelcamara on this.

This changed also the flow regarding `Table._attempt_upload`, since now is a callback method in the `before_insert` and `before_update`. So while the old flow was:
`_attempt_upload`, `callable_values`, `before_callback`, `operation`

the new one is:
`callable_values`, `before_callback`, `operation`
