### PR TITLE
Table name bugfixes

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -346,19 +346,6 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
     def rowslice(self, rows, minimum=0, maximum=None):
         return rows
 
-    def alias(self, table, alias):
-        other = copy.copy(table)
-        other['_ot'] = other._ot or other.sqlsafe
-        other['ALL'] = SQLALL(other)
-        other['_tablename'] = alias
-        for fieldname in other.fields:
-            other[fieldname] = copy.copy(other[fieldname])
-            other[fieldname]._tablename = alias
-            other[fieldname].tablename = alias
-            other[fieldname].table = other
-        table._db[alias] = other
-        return other
-
 
 class DebugHandler(ExecutionHandler):
     def before_execute(self, command):
@@ -425,8 +412,7 @@ class SQLAdapter(BaseAdapter):
         if isinstance(expression, Field):
             et = expression.table
             if not colnames:
-                table_rname = et.query_alias
-                rv = '%s.%s' % (table_rname, expression._rname or
+                rv = '%s.%s' % (et.sqlsafe, expression._rname or
                                 (self.dialect.quote(expression.name)))
             else:
                 rv = '%s.%s' % (self.dialect.quote(et._tablename),
@@ -480,10 +466,10 @@ class SQLAdapter(BaseAdapter):
     def _insert(self, table, fields):
         if fields:
             return self.dialect.insert(
-                table.sqlsafe,
+                table._rname,
                 ','.join(el[0].sqlsafe_name for el in fields),
                 ','.join(self.expand(v, f.type) for f, v in fields))
-        return self.dialect.insert_empty(table.sqlsafe)
+        return self.dialect.insert_empty(table._rname)
 
     def insert(self, table, fields):
         query = self._insert(table, fields)
@@ -511,7 +497,6 @@ class SQLAdapter(BaseAdapter):
 
     def _update(self, table, query, fields):
         sql_q = ''
-        tablename = table.sqlsafe
         query_env = dict(current_scope=[table._tablename])
         if query:
             if use_common_filters(query):
@@ -521,7 +506,7 @@ class SQLAdapter(BaseAdapter):
             '%s=%s' % (field.sqlsafe_name,
                 self.expand(value, field.type, query_env=query_env))
             for (field, value) in fields])
-        return self.dialect.update(tablename, sql_v, sql_q)
+        return self.dialect.update(table, sql_v, sql_q)
 
     def update(self, table, query, fields):
         sql = self._update(table, query, fields)
@@ -539,13 +524,12 @@ class SQLAdapter(BaseAdapter):
 
     def _delete(self, table, query):
         sql_q = ''
-        tablename = table.sqlsafe
         query_env = dict(current_scope=[table._tablename])
         if query:
             if use_common_filters(query):
                 query = self.common_filter(query, [table])
             sql_q = self.expand(query, query_env=query_env)
-        return self.dialect.delete(tablename, sql_q)
+        return self.dialect.delete(table, sql_q)
 
     def delete(self, table, query):
         sql = self._delete(table, query)

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -412,7 +412,7 @@ class SQLAdapter(BaseAdapter):
         if isinstance(expression, Field):
             et = expression.table
             if not colnames:
-                rv = '%s.%s' % (et.sqlsafe, expression._rname or
+                rv = '%s.%s' % (et.sql_shortref, expression._rname or
                                 (self.dialect.quote(expression.name)))
             else:
                 rv = '%s.%s' % (self.dialect.quote(et._tablename),
@@ -685,7 +685,7 @@ class SQLAdapter(BaseAdapter):
         if (limitby and not groupby and query_tables and orderby_on_limitby and
            not orderby):
             sql_ord = ', '.join([
-                tablemap[t].sqlsafe + '.' + tablemap[t][x].sqlsafe_name
+                tablemap[t].sql_shortref + '.' + tablemap[t][x].sqlsafe_name
                 for t in query_tables if not isinstance(tablemap[t], Select)
                 for x in (hasattr(tablemap[t], '_primarykey') and
                           tablemap[t]._primarykey or ['_id'])

--- a/pydal/adapters/firebird.py
+++ b/pydal/adapters/firebird.py
@@ -51,6 +51,7 @@ class FireBird(SQLAdapter):
         return long(self.cursor.fetchone()[0])
 
     def create_sequence_and_triggers(self, query, table, **args):
+        # FIXME: use table._rname instead?
         tablename = table._tablename
         sequence_name = table._sequence_name
         trigger_name = table._trigger_name

--- a/pydal/adapters/firebird.py
+++ b/pydal/adapters/firebird.py
@@ -51,8 +51,7 @@ class FireBird(SQLAdapter):
         return long(self.cursor.fetchone()[0])
 
     def create_sequence_and_triggers(self, query, table, **args):
-        # FIXME: use table._rname instead?
-        tablename = table._tablename
+        tablename = table._rname
         sequence_name = table._sequence_name
         trigger_name = table._trigger_name
         self.execute(query)

--- a/pydal/adapters/google.py
+++ b/pydal/adapters/google.py
@@ -374,7 +374,7 @@ class GoogleDatastore(NoSQLAdapter):
                 (t.name == 'nativeRef' and item) or getattr(item, t.name)
                 for t in fields
             ] for item in items]
-        colnames = ['%s.%s' % (table._tablename, t.name) for t in fields]
+        colnames = [t.longname for t in fields]
         processor = attributes.get('processor', self.parse)
         return processor(rows, fields, colnames, False)
 

--- a/pydal/adapters/ingres.py
+++ b/pydal/adapters/ingres.py
@@ -32,19 +32,18 @@ class Ingres(SQLAdapter):
         # post create table auto inc code (if needed)
         # modify table to btree for performance....
         # Older Ingres releases could use rule/trigger like Oracle above.
-        # FIXME: use table._rname instead in all 3 places?
         if hasattr(table, '_primarykey'):
             modify_tbl_sql = 'modify %s to btree unique on %s' % \
-                (table._tablename,
+                (table._rname,
                  ', '.join(["'%s'" % x for x in table.primarykey]))
             self.execute(modify_tbl_sql)
         else:
-            tmp_seqname = '%s_iisq' % table._tablename
+            tmp_seqname = '%s_iisq' % table._raw_rname
             query = query.replace(self.dialect.INGRES_SEQNAME, tmp_seqname)
             self.execute('create sequence %s' % tmp_seqname)
             self.execute(query)
             self.execute(
-                'modify %s to btree unique on %s' % (table._tablename, 'id'))
+                'modify %s to btree unique on %s' % (table._rname, 'id'))
 
 
 @adapters.register_for('ingresu')

--- a/pydal/adapters/ingres.py
+++ b/pydal/adapters/ingres.py
@@ -32,6 +32,7 @@ class Ingres(SQLAdapter):
         # post create table auto inc code (if needed)
         # modify table to btree for performance....
         # Older Ingres releases could use rule/trigger like Oracle above.
+        # FIXME: use table._rname instead in all 3 places?
         if hasattr(table, '_primarykey'):
             modify_tbl_sql = 'modify %s to btree unique on %s' % \
                 (table._tablename,

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -326,7 +326,7 @@ class Mongo(NoSQLAdapter):
                     # Mongodb reserved uuid key
                     colname = (tablename + '.' + 'id', '_id')
                 else:
-                    colname = (tablename + '.' + field.name, field.name)
+                    colname = (field.longname, field.name)
             elif not isinstance(query, Expression):
                 colname = (field.name, field.name)
             colnames.append(colname[1])

--- a/pydal/adapters/oracle.py
+++ b/pydal/adapters/oracle.py
@@ -61,8 +61,7 @@ class Oracle(SQLAdapter):
 
     def create_sequence_and_triggers(self, query, table, **args):
         tablename = table._rname
-        # FIXME: use _rname instead?
-        id_name = table._id.name
+        id_name = table._id._rname
         sequence_name = table._sequence_name
         trigger_name = table._trigger_name
         self.execute(query)

--- a/pydal/adapters/oracle.py
+++ b/pydal/adapters/oracle.py
@@ -61,6 +61,7 @@ class Oracle(SQLAdapter):
 
     def create_sequence_and_triggers(self, query, table, **args):
         tablename = table._rname
+        # FIXME: use _rname instead?
         id_name = table._id.name
         sequence_name = table._sequence_name
         trigger_name = table._trigger_name
@@ -94,8 +95,8 @@ class Oracle(SQLAdapter):
 
     def _build_value_for_insert(self, field, value, r_values):
         if field.type is 'text':
-            r_values[':' + field.sqlsafe_name] = self.expand(value, field.type)
-            return ':' + field.sqlsafe_name
+            r_values[':' + field._rname] = self.expand(value, field.type)
+            return ':' + field._rname
         return self.expand(value, field.type)
 
     def _insert(self, table, fields):
@@ -103,7 +104,7 @@ class Oracle(SQLAdapter):
             r_values = {}
             return self.dialect.insert(
                 table._rname,
-                ','.join(el[0].sqlsafe_name for el in fields),
+                ','.join(el[0]._rname for el in fields),
                 ','.join(
                     self._build_value_for_insert(f, v, r_values)
                     for f, v in fields)

--- a/pydal/adapters/oracle.py
+++ b/pydal/adapters/oracle.py
@@ -60,7 +60,7 @@ class Oracle(SQLAdapter):
         return long(self.cursor.fetchone()[0])
 
     def create_sequence_and_triggers(self, query, table, **args):
-        tablename = table._rname or table._tablename
+        tablename = table._rname
         id_name = table._id.name
         sequence_name = table._sequence_name
         trigger_name = table._trigger_name
@@ -102,13 +102,13 @@ class Oracle(SQLAdapter):
         if fields:
             r_values = {}
             return self.dialect.insert(
-                table.sqlsafe,
+                table._rname,
                 ','.join(el[0].sqlsafe_name for el in fields),
                 ','.join(
                     self._build_value_for_insert(f, v, r_values)
                     for f, v in fields)
                 ), r_values
-        return self.dialect.insert_empty(table.sqlsafe), None
+        return self.dialect.insert_empty(table._rname), None
 
     def insert(self, table, fields):
         query, values = self._insert(table, fields)

--- a/pydal/adapters/postgres.py
+++ b/pydal/adapters/postgres.py
@@ -118,11 +118,11 @@ class Postgre(with_metaclass(PostgreMeta, SQLAdapter)):
                 self._last_insert = (table._id, 1)
                 retval = table._id.name
             return self.dialect.insert(
-                table.sqlsafe,
+                table._rname,
                 ','.join(el[0].sqlsafe_name for el in fields),
                 ','.join(self.expand(v, f.type) for f, v in fields),
                 retval)
-        return self.dialect.insert_empty(table.sqlsafe)
+        return self.dialect.insert_empty(table._rname)
 
     @with_connection
     def prepare(self, key):

--- a/pydal/adapters/postgres.py
+++ b/pydal/adapters/postgres.py
@@ -116,10 +116,10 @@ class Postgre(with_metaclass(PostgreMeta, SQLAdapter)):
             retval = None
             if hasattr(table, '_id'):
                 self._last_insert = (table._id, 1)
-                retval = table._id.name
+                retval = table._id._rname
             return self.dialect.insert(
                 table._rname,
-                ','.join(el[0].sqlsafe_name for el in fields),
+                ','.join(el[0]._rname for el in fields),
                 ','.join(self.expand(v, f.type) for f, v in fields),
                 retval)
         return self.dialect.insert_empty(table._rname)

--- a/pydal/adapters/sap.py
+++ b/pydal/adapters/sap.py
@@ -45,5 +45,5 @@ class SAPDB(SQLAdapter):
         self.execute('CREATE SEQUENCE %s;' % table._sequence_name)
         self.execute(
             "ALTER TABLE %s ALTER COLUMN %s SET DEFAULT NEXTVAL('%s');" %
-            (table._rname, table._id.name, table._sequence_name))
+            (table._rname, table._id._rname, table._sequence_name))
         self.execute(query)

--- a/pydal/adapters/sap.py
+++ b/pydal/adapters/sap.py
@@ -45,5 +45,5 @@ class SAPDB(SQLAdapter):
         self.execute('CREATE SEQUENCE %s;' % table._sequence_name)
         self.execute(
             "ALTER TABLE %s ALTER COLUMN %s SET DEFAULT NEXTVAL('%s');" %
-            (table._tablename, table._id.name, table._sequence_name))
+            (table._rname, table._id.name, table._sequence_name))
         self.execute(query)

--- a/pydal/adapters/sqlite.py
+++ b/pydal/adapters/sqlite.py
@@ -87,7 +87,7 @@ class SQLite(SQLAdapter):
         counter = super(SQLite, self).delete(table, query)
         if counter:
             for field in table._referenced_by:
-                if field.type == 'reference ' + table._tablename \
+                if field.type == 'reference ' + table._dalname \
                    and field.ondelete == 'CASCADE':
                     db(field.belongs(deleted)).delete()
         return counter

--- a/pydal/contrib/imap_adapter.py
+++ b/pydal/contrib/imap_adapter.py
@@ -601,7 +601,7 @@ class IMAPAdapter(NoSQLAdapter):
         if allfields:
             colnames = ["%s.%s" % (tablename, field) for field in self.search_fields.keys()]
         else:
-            colnames = ["%s.%s" % (tablename, field.name) for field in fields]
+            colnames = [field.longname for field in fields]
 
         for k in colnames:
             imapfields_dict[k] = k

--- a/pydal/contrib/imap_adapter.py
+++ b/pydal/contrib/imap_adapter.py
@@ -524,7 +524,7 @@ class IMAPAdapter(NoSQLAdapter):
         fetch_results = list()
 
         if isinstance(query, Query):
-            tablename = self.get_table(query)
+            tablename = self.get_table(query)._dalname
             mailbox = self.connection.mailbox_names.get(tablename, None)
             if mailbox is None:
                 raise ValueError("Mailbox name not found: %s" % mailbox)
@@ -800,10 +800,11 @@ class IMAPAdapter(NoSQLAdapter):
         else:
             raise NotImplementedError("IMAP empty insert is not implemented")
 
-    def update(self, tablename, query, fields):
+    def update(self, table, query, fields):
         # TODO: the adapter should implement an .expand method
         commands = list()
         rowcount = 0
+        tablename = table._dalname
         if use_common_filters(query):
             query = self.common_filter(query, [tablename,])
         mark = []
@@ -855,8 +856,9 @@ class IMAPAdapter(NoSQLAdapter):
             counter = len(store_list)
         return counter
 
-    def delete(self, tablename, query):
+    def delete(self, table, query):
         counter = 0
+        tablename = table._dalname
         if query:
             if use_common_filters(query):
                 query = self.common_filter(query, [tablename,])

--- a/pydal/dialects/base.py
+++ b/pydal/dialects/base.py
@@ -148,13 +148,15 @@ class SQLDialect(CommonDialect):
     def where(self, query):
         return 'WHERE %s' % query
 
-    def update(self, tablename, values, where=None):
+    def update(self, table, values, where=None):
+        tablename = self.writing_alias(table)
         whr = ''
         if where:
             whr = ' %s' % self.where(where)
         return 'UPDATE %s SET %s%s;' % (tablename, values, whr)
 
-    def delete(self, tablename, where=None):
+    def delete(self, table, where=None):
+        tablename = self.writing_alias(table)
         whr = ''
         if where:
             whr = ' %s' % self.where(where)
@@ -470,18 +472,18 @@ class SQLDialect(CommonDialect):
         return 'PRIMARY KEY(%s)' % key
 
     def drop_table(self, table, mode):
-        return ['DROP TABLE %s;' % table.sqlsafe]
+        return ['DROP TABLE %s;' % table._rname]
 
     def truncate(self, table, mode=''):
         if mode:
             mode = " %s" % mode
-        return ['TRUNCATE TABLE %s%s;' % (table.sqlsafe, mode)]
+        return ['TRUNCATE TABLE %s%s;' % (table._rname, mode)]
 
     def create_index(self, name, table, expressions, unique=False):
         uniq = ' UNIQUE' if unique else ''
         with self.adapter.index_expander():
             rv = 'CREATE%s INDEX %s ON %s (%s);' % (
-                uniq, self.quote(name), table.sqlsafe, ','.join(
+                uniq, self.quote(name), table._rname, ','.join(
                     self.expand(field) for field in expressions))
         return rv
 
@@ -493,6 +495,9 @@ class SQLDialect(CommonDialect):
 
     def concat_add(self, tablename):
         return ', ADD '
+
+    def writing_alias(self, table):
+        return table.sqlsafe_alias
 
 
 class NoSQLDialect(CommonDialect):

--- a/pydal/dialects/base.py
+++ b/pydal/dialects/base.py
@@ -497,7 +497,7 @@ class SQLDialect(CommonDialect):
         return ', ADD '
 
     def writing_alias(self, table):
-        return table.sqlsafe_alias
+        return table.sql_fullref
 
 
 class NoSQLDialect(CommonDialect):

--- a/pydal/dialects/firebird.py
+++ b/pydal/dialects/firebird.py
@@ -105,10 +105,10 @@ class FireBirdDialect(SQLDialect):
     def drop_table(self, table, mode):
         sequence_name = table._sequence_name
         return [
-            'DROP TABLE %s %s;' % (table.sqlsafe, mode),
+            'DROP TABLE %s %s;' % (table._rname, mode),
             'DROP GENERATOR %s;' % sequence_name]
 
     def truncate(self, table, mode=''):
         return [
-            'DELETE FROM %s;' % table._tablename,
+            'DELETE FROM %s;' % table._rname,
             'SET GENERATOR %s TO 0;' % table._sequence_name]

--- a/pydal/dialects/mssql.py
+++ b/pydal/dialects/mssql.py
@@ -96,14 +96,14 @@ class MSSQLDialect(SQLDialect):
         if where:
             whr = ' %s' % self.where(where)
         return 'UPDATE %s SET %s FROM %s%s;' % (
-            table.sqlsafe, values, tablename, whr)
+            table.sql_shortref, values, tablename, whr)
 
     def delete(self, table, where=None):
         tablename = self.writing_alias(table)
         whr = ''
         if where:
             whr = ' %s' % self.where(where)
-        return 'DELETE %s FROM %s%s;' % (table.sqlsafe, tablename, whr)
+        return 'DELETE %s FROM %s%s;' % (table.sql_shortref, tablename, whr)
 
     def select(self, fields, tables, where=None, groupby=None, having=None,
                orderby=None, limitby=None, distinct=False, for_update=False):

--- a/pydal/dialects/mssql.py
+++ b/pydal/dialects/mssql.py
@@ -90,6 +90,21 @@ class MSSQLDialect(SQLDialect):
     def varquote(self, val):
         return varquote_aux(val, '[%s]')
 
+    def update(self, table, values, where=None):
+        tablename = self.writing_alias(table)
+        whr = ''
+        if where:
+            whr = ' %s' % self.where(where)
+        return 'UPDATE %s SET %s FROM %s%s;' % (
+            table.sqlsafe, values, tablename, whr)
+
+    def delete(self, table, where=None):
+        tablename = self.writing_alias(table)
+        whr = ''
+        if where:
+            whr = ' %s' % self.where(where)
+        return 'DELETE %s FROM %s%s;' % (table.sqlsafe, tablename, whr)
+
     def select(self, fields, tables, where=None, groupby=None, having=None,
                orderby=None, limitby=None, distinct=False, for_update=False):
         dst, whr, grp, order, limit, offset, upd = '', '', '', '', '', '', ''

--- a/pydal/dialects/mssql.py
+++ b/pydal/dialects/mssql.py
@@ -77,7 +77,7 @@ class MSSQLDialect(SQLDialect):
     def type_reference_tfk(self):
         return ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY ' + \
             '(%(field_name)s) REFERENCES %(foreign_table)s ' + \
-            '(%(foreign_key)s) ON DELETE %(on_delete_action)s',
+            '(%(foreign_key)s) ON DELETE %(on_delete_action)s'
 
     @sqltype_for('geometry')
     def type_geometry(self):

--- a/pydal/dialects/mssql.py
+++ b/pydal/dialects/mssql.py
@@ -180,7 +180,7 @@ class MSSQLDialect(SQLDialect):
         return '; ALTER TABLE %s ADD ' % tablename
 
     def drop_index(self, name, table):
-        return 'DROP INDEX %s ON %s;' % (self.quote(name), table.sqlsafe)
+        return 'DROP INDEX %s ON %s;' % (self.quote(name), table._rname)
 
     def st_astext(self, first, query_env={}):
         return '%s.STAsText()' % self.expand(first, query_env=query_env)
@@ -393,7 +393,7 @@ class VerticaDialect(MSSQLDialect):
     def truncate(self, table, mode=''):
         if mode:
             mode = " %s" % mode
-        return ['TRUNCATE %s%s;' % (table.sqlsafe, mode)]
+        return ['TRUNCATE %s%s;' % (table._rname, mode)]
 
     def select(self, *args, **kwargs):
         return SQLDialect.select(self, *args, **kwargs)

--- a/pydal/dialects/mssql.py
+++ b/pydal/dialects/mssql.py
@@ -75,7 +75,7 @@ class MSSQLDialect(SQLDialect):
 
     @sqltype_for('reference TFK')
     def type_reference_tfk(self):
-        return ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY ' + \
+        return ' CONSTRAINT FK_%(constraint_name)s_PK FOREIGN KEY ' + \
             '(%(field_name)s) REFERENCES %(foreign_table)s ' + \
             '(%(foreign_key)s) ON DELETE %(on_delete_action)s'
 

--- a/pydal/dialects/mysql.py
+++ b/pydal/dialects/mysql.py
@@ -61,7 +61,7 @@ class MySQLDialect(SQLDialect):
         whr = ''
         if where:
             whr = ' %s' % self.where(where)
-        return 'DELETE %s FROM %s%s;' % (table.sqlsafe, tablename, whr)
+        return 'DELETE %s FROM %s%s;' % (table.sql_shortref, tablename, whr)
 
     @property
     def random(self):

--- a/pydal/dialects/mysql.py
+++ b/pydal/dialects/mysql.py
@@ -56,6 +56,13 @@ class MySQLDialect(SQLDialect):
     def insert_empty(self, table):
         return 'INSERT INTO %s VALUES (DEFAULT);' % table
 
+    def delete(self, table, where=None):
+        tablename = self.writing_alias(table)
+        whr = ''
+        if where:
+            whr = ' %s' % self.where(where)
+        return 'DELETE %s FROM %s%s;' % (table.sqlsafe, tablename, whr)
+
     @property
     def random(self):
         return 'RAND()'
@@ -86,8 +93,8 @@ class MySQLDialect(SQLDialect):
     def drop_table(self, table, mode):
         # breaks db integrity but without this mysql does not drop table
         return [
-            'SET FOREIGN_KEY_CHECKS=0;', 'DROP TABLE %s;' % table.sqlsafe,
+            'SET FOREIGN_KEY_CHECKS=0;', 'DROP TABLE %s;' % table._rname,
             'SET FOREIGN_KEY_CHECKS=1;']
 
     def drop_index(self, name, table):
-        return 'DROP INDEX %s ON %s;' % (self.quote(name), table.sqlsafe)
+        return 'DROP INDEX %s ON %s;' % (self.quote(name), table._rname)

--- a/pydal/dialects/oracle.py
+++ b/pydal/dialects/oracle.py
@@ -115,5 +115,5 @@ class OracleDialect(SQLDialect):
     def drop_table(self, table, mode):
         sequence_name = table._sequence_name
         return [
-            'DROP TABLE %s %s;' % (table.sqlsafe, mode),
+            'DROP TABLE %s %s;' % (table._rname, mode),
             'DROP SEQUENCE %s;' % sequence_name]

--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -58,7 +58,7 @@ class PostgreDialect(SQLDialect):
     def insert(self, table, fields, values, returning=None):
         ret = ''
         if returning:
-            ret = 'RETURNING %s' % self.quote(returning)
+            ret = 'RETURNING %s' % returning
         return 'INSERT INTO %s(%s) VALUES (%s)%s;' % (
             table, fields, values, ret)
 

--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -115,7 +115,7 @@ class PostgreDialect(SQLDialect):
     def drop_table(self, table, mode):
         if mode not in ['restrict', 'cascade', '']:
             raise ValueError('Invalid mode: %s' % mode)
-        return ['DROP TABLE ' + table.sqlsafe + ' ' + mode + ';']
+        return ['DROP TABLE ' + table._rname + ' ' + mode + ';']
 
     def create_index(self, name, table, expressions, unique=False, where=None):
         uniq = ' UNIQUE' if unique else ''
@@ -124,7 +124,7 @@ class PostgreDialect(SQLDialect):
             whr = ' %s' % self.where(where)
         with self.adapter.index_expander():
             rv = 'CREATE%s INDEX %s ON %s (%s)%s;' % (
-                uniq, self.quote(name), table.sqlsafe, ','.join(
+                uniq, self.quote(name), table._rname, ','.join(
                     self.expand(field) for field in expressions), whr)
         return rv
 

--- a/pydal/dialects/sqlite.py
+++ b/pydal/dialects/sqlite.py
@@ -40,10 +40,16 @@ class SQLiteDialect(SQLDialect):
             for_update)
 
     def truncate(self, table, mode=''):
-        tablename = table._tablename
+        tablename = self.adapter.expand(table._raw_rname, 'string')
         return [
-            self.delete(tablename),
-            self.delete('sqlite_sequence', "name='%s'" % tablename)]
+            self.delete(table),
+            "DELETE FROM sqlite_sequence WHERE name=%s" % tablename]
+
+    def writing_alias(self, table):
+        if table._dalname != table._tablename:
+            raise SyntaxError(
+                'SQLite does not support UPDATE/DELETE on aliased table')
+        return table._rname
 
 
 @dialects.register_for(Spatialite)

--- a/pydal/dialects/teradata.py
+++ b/pydal/dialects/teradata.py
@@ -97,4 +97,4 @@ class TeradataDialect(SQLDialect):
             dst, limit, fields, tables, whr, grp, order, offset, upd)
 
     def truncate(self, table, mode=''):
-        return ['DELETE FROM %s ALL;' % table._tablename]
+        return ['DELETE FROM %s ALL;' % table._rname]

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -26,6 +26,7 @@ from .helpers.methods import list_represent, bar_decode_integer, \
     bar_decode_string, bar_encode, archive_record, cleanup, \
     use_common_filters, pluralize
 from .helpers.serializers import serializers
+from .utils import deprecated
 
 
 DEFAULTLENGTH = {'string': 512, 'password': 512, 'upload': 512, 'text': 2**15,
@@ -617,19 +618,29 @@ class Table(Serializable, BasicStorage):
         return self._db._adapter.dialect._as(self._dalname, self._tablename)
 
     @property
+    @deprecated('sqlsafe', 'sql_shortref', 'Table')
     def sqlsafe(self):
+        return self.sql_shortref
+
+    @property
+    @deprecated('sqlsafe_alias', 'sql_fullref', 'Table')
+    def sqlsafe_alias(self):
+        return self.sql_fullref
+
+    @property
+    def sql_shortref(self):
         if self._tablename == self._dalname:
             return self._rname
         return self._db._adapter.sqlsafe_table(self._tablename)
 
     @property
-    def sqlsafe_alias(self):
+    def sql_fullref(self):
         if self._tablename == self._dalname:
             return self._rname
         return self._db._adapter.sqlsafe_table(self._tablename, self._rname)
 
     def query_name(self, *args, **kwargs):
-        return (self.sqlsafe_alias,)
+        return (self.sql_fullref,)
 
     def _drop(self, mode=''):
         return self._db._adapter.dialect.drop_table(self, mode)
@@ -1178,7 +1189,7 @@ class Select(BasicStorage):
         return (sql,)
 
     @property
-    def sqlsafe(self):
+    def sql_shortref(self):
         if self._tablename is None:
             raise SyntaxError("Subselect must be aliased for use in a JOIN")
         return self._db._adapter.dialect.quote(self._tablename)
@@ -1857,7 +1868,7 @@ class Field(Expression, Serializable):
     @property
     def sqlsafe(self):
         if self._table:
-            return self._table.sqlsafe + '.' + \
+            return self._table.sql_shortref + '.' + \
                 (self._rname or self._db._adapter.sqlsafe_field(self.name))
         return '<no table>.%s' % self.name
 

--- a/tests/indexes.py
+++ b/tests/indexes.py
@@ -28,7 +28,7 @@ class TestIndexesExpressions(unittest.TestCase):
         with db._adapter.index_expander():
             coalesce_sql = str(db.tt.bb.coalesce(None))
         expected_sql = 'CREATE INDEX %s ON %s (%s,%s);' % (
-            db._adapter.dialect.quote('idx_aa_and_bb'), db.tt.sqlsafe,
+            db._adapter.dialect.quote('idx_aa_and_bb'), db.tt.sql_shortref,
             db.tt.aa.sqlsafe_name, coalesce_sql)
         self.assertEqual(sql, expected_sql)
         rv = db.tt.create_index(

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -1301,6 +1301,7 @@ class TestTableAliasing(DALtest):
         tab1 = db.t1.with_alias('test1')
         tab2 = db.t2.with_alias('test2')
         self.assertIs(tab2.id, tab2.pk)
+        self.assertIs(tab2._id, tab2.pk)
         self.assertEqual(tab1._dalname, 't1')
         self.assertEqual(tab1._tablename, 'test1')
         self.assertEqual(tab2._dalname, 't2')

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -678,7 +678,7 @@ class TestSubselect(DALtest):
         with self.assertRaises(SyntaxError):
             sub.query_name()
         with self.assertRaises(SyntaxError):
-            sub.sqlsafe
+            sub.sql_shortref
         with self.assertRaises(SyntaxError):
             sub.on(sub.aa != None)
         # Alias checks
@@ -692,7 +692,7 @@ class TestSubselect(DALtest):
         self.assertEqual(sub._raw_rname, None)
         self.assertEqual(sub._dalname, None)
         self.assertEqual(sub.query_name()[0], str(sub))
-        self.assertEqual(sub.sqlsafe, db._adapter.dialect.quote('foo'))
+        self.assertEqual(sub.sql_shortref, db._adapter.dialect.quote('foo'))
         self.assertIsInstance(sub.on(sub.aa != None), Expression)
 
     def testSelectArguments(self):


### PR DESCRIPTION
This changeset fixes update()/delete() on aliased tables and bugs caused by using the wrong table/field name in various queries (especially in migrator).

### Changes in class `Table`
- `Table._ot` has been renamed to `Table._dalname` and it is always set to the original internal table name.
- `Table._rname` now defaults to quoted `Table._dalname` (except when the table is not associated with any database, only then it gets set to `None`).
- Added `Table._raw_rname` which is the unquoted version of `_rname` (for generating extra identifers based on the backend table name, e.g. sequence names).
- `Table.sqlsafe` renamed to `sql_shortref`.
- `Table.sqlsafe_alias` renamed to `sql_fullref`.

Example where they belong in a query: `SELECT * FROM sql_fullref WHERE sql_shortref.id > 0`

### Changes in class `Field`
- `Field.sqlsafe` now raises exception when the field object is not associated with any table.
- Deprecated `Field.sqlsafe_name`, use `Field._rname` instead.
- Added property `Field.longname` which returns field reference string as 'tablename.fieldname' (as oposed to 'table_rname.field_rname' returned by `sqlsafe`).
- `Field.clone()` now returns the new `Field` object without link to any table and with empty `_rname` if it needs to be requoted.
- Added method `Field.bind()` which links the field to a table. When the field is already linked, it raises exception. It also sets empty `Field._rname` to quoted `Field.name`. This method is called internally by table/subselect constructor.
- Added `Field._raw_rname` which is the unquoted version of `_rname`.

### Other changes
- Removed `BaseAdatper.alias()`, the code was move to `Table.with_alias()` where it belongs + bugfixes.
- `SQLDialect.update()` and `SQLDialect.delete()` now take a `Table` object instead of tablename. This change was necessary because `MySQLDialect.delete()` and also other dialects need to access both `sql_shortref` and `sql_fullref` when the table is aliased.
- New method `writing_alias()` added to `SQLDialect`. The method simply returns `table.sql_fullref`. It was added so that dialects like SQLite which don't support `UPDATE/DELETE` on aliased tables can raise exception without reimplementing the whole `update()`/`delete()` methods.
- IMAP adapter was updated to new API (passing `Table` objects instead of tablename). I forgot to do this in the subselect pull request. Beware that this change is untested.
- `Field._rname` and `Field._raw_rname` will now be stored in pickled table metadata files.