### PR TITLE
Web2py compatibility bugfixes

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -745,10 +745,12 @@ class SQLAdapter(BaseAdapter):
         key = self.uri + '/' + sql
         key = hashlib_md5(key).hexdigest()
         args = (sql, fields, attributes, colnames)
-        return cache_model(
+        ret = cache_model(
             key,
             lambda self=self, args=args: self._select_aux(*args),
             time_expire)
+        ret._restore_fields(fields)
+        return ret
 
     def select(self, query, fields, attributes):
         colnames, sql = self._select_wcols(query, fields, **attributes)

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -346,6 +346,12 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
     def rowslice(self, rows, minimum=0, maximum=None):
         return rows
 
+    def sqlsafe_table(self, tablename, original_tablename=None):
+        return tablename
+
+    def sqlsafe_field(self, fieldname):
+        return fieldname
+
 
 class DebugHandler(ExecutionHandler):
     def before_execute(self, command):
@@ -940,12 +946,6 @@ class NoSQLAdapter(BaseAdapter):
     def nested_select(self, *args, **kwargs):
         raise NotOnNOSQLError(
             "Nested queries are not supported on NoSQL databases")
-
-    def sqlsafe_table(self, tablename, original_tablename=None):
-        return tablename
-
-    def sqlsafe_field(self, fieldname):
-        return fieldname
 
 
 class NullAdapter(BaseAdapter):

--- a/pydal/migrator.py
+++ b/pydal/migrator.py
@@ -429,7 +429,7 @@ class Migrator(object):
                     drop_expr % (table._rname, key_tmp)
                 ]
                 metadata_change = True
-            elif sql_fields[key]['type'] != sql_fields_old[key]['type']:
+            elif sql_fields[key] != sql_fields_old[key]:
                 sql_fields_current[key] = sql_fields[key]
                 metadata_change = True
 

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2933,6 +2933,16 @@ class Rows(BasicRows):
             return row[keys[0]]
         return row
 
+    def __getstate__(self):
+        ret = self.__dict__.copy()
+        del ret['fields']
+        return ret
+
+    def _restore_fields(self, fields):
+        if not hasattr(self, 'fields'):
+            self.fields = fields
+        return self
+
 
 @implements_iterator
 class IterRows(BasicRows):

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2676,7 +2676,7 @@ class Rows(BasicRows):
             raise Exception('Cannot & incompatible Rows objects')
         records = self.records + other.records
         return self.__class__(
-            self.db, records, self.colnames,
+            self.db, records, self.colnames, fields=self.fields,
             compact=self.compact or other.compact)
 
     def __or__(self, other):
@@ -2686,7 +2686,7 @@ class Rows(BasicRows):
                    if record not in self.records]
         records = self.records + records
         return self.__class__(
-            self.db, records, self.colnames,
+            self.db, records, self.colnames, fields=self.fields,
             compact=self.compact or other.compact)
 
     def __len__(self):
@@ -2694,7 +2694,8 @@ class Rows(BasicRows):
 
     def __getslice__(self, a, b):
         return self.__class__(
-            self.db, self.records[a:b], self.colnames, compact=self.compact)
+            self.db, self.records[a:b], self.colnames, compact=self.compact,
+            fields=self.fields)
 
     def __getitem__(self, i):
         row = self.records[i]
@@ -2743,7 +2744,8 @@ class Rows(BasicRows):
         """
         if not self:
             return self.__class__(
-                self.db, [], self.colnames, compact=self.compact)
+                self.db, [], self.colnames, compact=self.compact,
+                fields=self.fields)
         records = []
         if limitby:
             a, b = limitby
@@ -2758,7 +2760,8 @@ class Rows(BasicRows):
                 if k == b:
                     break
         return self.__class__(
-            self.db, records, self.colnames, compact=self.compact)
+            self.db, records, self.colnames, compact=self.compact,
+            fields=self.fields)
 
     def exclude(self, f):
         """
@@ -2767,7 +2770,8 @@ class Rows(BasicRows):
         """
         if not self.records:
             return self.__class__(
-                self.db, [], self.colnames, compact=self.compact)
+                self.db, [], self.colnames, compact=self.compact,
+                fields=self.fields)
         removed = []
         i = 0
         while i < len(self):
@@ -2778,13 +2782,16 @@ class Rows(BasicRows):
             else:
                 i += 1
         return self.__class__(
-            self.db, removed, self.colnames, compact=self.compact)
+            self.db, removed, self.colnames, compact=self.compact,
+            fields=self.fields)
 
     def sort(self, f, reverse=False):
         """
         Returns a list of sorted elements (not sorted in place)
         """
-        rows = self.__class__(self.db, [], self.colnames, compact=self.compact)
+        rows = self.__class__(
+            self.db, [], self.colnames, compact=self.compact,
+            fields=self.fields)
         # When compact=True, iterating over self modifies each record,
         # so when sorting self, it is necessary to return a sorted
         # version of self.records rather than the sorted self directly.

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,5 +1,5 @@
 from ._compat import unittest
-from ._adapt import DEFAULT_URI
+from ._adapt import DEFAULT_URI, drop
 from pydal import DAL
 
 class DALtest(unittest.TestCase):
@@ -20,6 +20,6 @@ class DALtest(unittest.TestCase):
             db.commit()
             tablist = list(db.tables)
             for table in reversed(tablist):
-                db[table].drop()
+                drop(db[table])
             db.close()
         self._connections = []

--- a/tests/base.py
+++ b/tests/base.py
@@ -176,3 +176,13 @@ class TestChainedJoinUNIQUE(unittest.TestCase):
         drop(db.bb)
         drop(db.aa)
         db.close()
+
+class TestNullAdapter(unittest.TestCase):
+    # Test that NullAdapter can define tables
+
+    def testRun(self):
+        db = DAL(None)
+        db.define_table('no_table', Field('aa'))
+        self.assertIsInstance(db.no_table.aa, Field)
+        self.assertIsInstance(db.no_table['aa'], Field)
+        db.close()

--- a/tests/caching.py
+++ b/tests/caching.py
@@ -2,7 +2,7 @@ import time
 import pickle
 from pydal import DAL, Field
 from ._compat import unittest
-from ._adapt import DEFAULT_URI, IS_IMAP, drop
+from ._adapt import DEFAULT_URI, IS_IMAP, IS_MSSQL
 from ._helpers import DALtest
 
 
@@ -67,10 +67,12 @@ class TestCache(DALtest):
         db.tt.insert(aa='1', bb=2, cc=3)
         r0 = db(db.tt).select(db.tt.ALL)
         csv0 = str(r0)
-        r1 = db(db.tt).select(db.tt.ALL, cache=cache)
-        self.assertEqual(csv0, str(r1))
-        r2 = db(db.tt).select(db.tt.ALL, cache=cache)
-        self.assertEqual(csv0, str(r2))
+        # raw data returned by MSSQL cannot be pickled...
+        if not IS_MSSQL:
+            r1 = db(db.tt).select(db.tt.ALL, cache=cache)
+            self.assertEqual(csv0, str(r1))
+            r2 = db(db.tt).select(db.tt.ALL, cache=cache)
+            self.assertEqual(csv0, str(r2))
         r3 = db(db.tt).select(db.tt.ALL, cache=cache, cacheable=True)
         self.assertEqual(csv0, str(r3))
         r4 = db(db.tt).select(db.tt.ALL, cache=cache, cacheable=True)

--- a/tests/caching.py
+++ b/tests/caching.py
@@ -59,6 +59,7 @@ class TestCache(DALtest):
         r4 = db().select(db.tt.ALL, cache=(cache, 1000), cacheable=True)
         self.assertEqual(len(r0), len(r4))
 
+    @unittest.skipIf(IS_MSSQL, "Class nesting in ODBC driver breaks pickle")
     def testPickling(self):
         db = self.connect()
         cache = (PickleCache(), 1000)
@@ -67,12 +68,10 @@ class TestCache(DALtest):
         db.tt.insert(aa='1', bb=2, cc=3)
         r0 = db(db.tt).select(db.tt.ALL)
         csv0 = str(r0)
-        # raw data returned by MSSQL cannot be pickled...
-        if not IS_MSSQL:
-            r1 = db(db.tt).select(db.tt.ALL, cache=cache)
-            self.assertEqual(csv0, str(r1))
-            r2 = db(db.tt).select(db.tt.ALL, cache=cache)
-            self.assertEqual(csv0, str(r2))
+        r1 = db(db.tt).select(db.tt.ALL, cache=cache)
+        self.assertEqual(csv0, str(r1))
+        r2 = db(db.tt).select(db.tt.ALL, cache=cache)
+        self.assertEqual(csv0, str(r2))
         r3 = db(db.tt).select(db.tt.ALL, cache=cache, cacheable=True)
         self.assertEqual(csv0, str(r3))
         r4 = db(db.tt).select(db.tt.ALL, cache=cache, cacheable=True)

--- a/tests/caching.py
+++ b/tests/caching.py
@@ -1,7 +1,9 @@
 import time
+import pickle
 from pydal import DAL, Field
 from ._compat import unittest
 from ._adapt import DEFAULT_URI, IS_IMAP, drop
+from ._helpers import DALtest
 
 
 class SimpleCache(object):
@@ -9,6 +11,12 @@ class SimpleCache(object):
 
     def clear(self):
         self.storage.clear()
+
+    def _encode(self, value):
+        return value
+
+    def _decode(self, value):
+        return value
 
     def __call__(self, key, f, time_expire=300):
         dt = time_expire
@@ -21,18 +29,24 @@ class SimpleCache(object):
         if f is None:
             return None
         if item and (dt is None or item[0] > now - dt):
-            return item[1]
+            return self._decode(item[1])
 
         value = f()
-        self.storage[key] = (now, value)
+        self.storage[key] = (now, self._encode(value))
         return value
 
+class PickleCache(SimpleCache):
+    def _encode(self, value):
+        return pickle.dumps(value, pickle.HIGHEST_PROTOCOL)
+
+    def _decode(self, value):
+        return pickle.loads(value)
 
 @unittest.skipIf(IS_IMAP, "TODO: IMAP test")
-class TestCache(unittest.TestCase):
+class TestCache(DALtest):
     def testRun(self):
         cache = SimpleCache()
-        db = DAL(DEFAULT_URI, check_reserved=['all'])
+        db = self.connect()
         db.define_table('tt', Field('aa'))
         db.tt.insert(aa='1')
         r0 = db().select(db.tt.ALL)
@@ -44,4 +58,20 @@ class TestCache(unittest.TestCase):
         self.assertEqual(len(r0), len(r3))
         r4 = db().select(db.tt.ALL, cache=(cache, 1000), cacheable=True)
         self.assertEqual(len(r0), len(r4))
-        drop(db.tt)
+
+    def testPickling(self):
+        db = self.connect()
+        cache = (PickleCache(), 1000)
+        db.define_table('tt', Field('aa'), Field('bb', type='integer'),
+            Field('cc', type='decimal(5,2)'))
+        db.tt.insert(aa='1', bb=2, cc=3)
+        r0 = db(db.tt).select(db.tt.ALL)
+        csv0 = str(r0)
+        r1 = db(db.tt).select(db.tt.ALL, cache=cache)
+        self.assertEqual(csv0, str(r1))
+        r2 = db(db.tt).select(db.tt.ALL, cache=cache)
+        self.assertEqual(csv0, str(r2))
+        r3 = db(db.tt).select(db.tt.ALL, cache=cache, cacheable=True)
+        self.assertEqual(csv0, str(r3))
+        r4 = db(db.tt).select(db.tt.ALL, cache=cache, cacheable=True)
+        self.assertEqual(csv0, str(r4))


### PR DESCRIPTION
My recent contributions have apparently broken a lot of things in Web2py so I should fix that. This pull request fixes:
- `SQLFORM.factory()` errors.
- Migrations getting triggered on every request due to minor metadata differences which never actually migrate anything at all.
- Caching `Rows` objects to disk.

`SQLTABLE` class is also broken by table/field name refactoring but that needs to be fixed in Web2py. I'll open another pull request for that.