### PR TITLE
Init adapters properly even when reusing idle connection from pool

### DIFF
--- a/pydal/adapters/informix.py
+++ b/pydal/adapters/informix.py
@@ -31,7 +31,7 @@ class Informix(SQLAdapter):
     def connector(self):
         return self.driver.connect(self.dsn, **self.driver_args)
 
-    def after_reconnect(self):
+    def after_first_reconnect(self):
         self.dbms_version = int(self.connection.dbms_version.split('.')[0])
 
     @with_connection_or_raise

--- a/pydal/adapters/informix.py
+++ b/pydal/adapters/informix.py
@@ -31,7 +31,7 @@ class Informix(SQLAdapter):
     def connector(self):
         return self.driver.connect(self.dsn, **self.driver_args)
 
-    def after_connection(self):
+    def after_reconnect(self):
         self.dbms_version = int(self.connection.dbms_version.split('.')[0])
 
     @with_connection_or_raise

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -70,7 +70,7 @@ class Mongo(NoSQLAdapter):
         conn.commit = lambda: None
         return conn
 
-    def after_reconnect(self):
+    def after_first_reconnect(self):
         #: server version
         self._server_version = self.connection.command(
             "serverStatus")['version']

--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -70,7 +70,7 @@ class Mongo(NoSQLAdapter):
         conn.commit = lambda: None
         return conn
 
-    def after_connection(self):
+    def after_reconnect(self):
         #: server version
         self._server_version = self.connection.command(
             "serverStatus")['version']

--- a/pydal/adapters/postgres.py
+++ b/pydal/adapters/postgres.py
@@ -101,7 +101,6 @@ class Postgre(with_metaclass(PostgreMeta, SQLAdapter)):
     def after_connection(self):
         self.execute("SET CLIENT_ENCODING TO 'UTF8'")
         self.execute("SET standard_conforming_strings=on;")
-        self._config_json()
 
     def lastrowid(self, table):
         if self._last_insert:
@@ -141,7 +140,7 @@ class Postgre(with_metaclass(PostgreMeta, SQLAdapter)):
 class PostgrePsyco(Postgre):
     drivers = ('psycopg2',)
 
-    def _config_json(self):
+    def after_reconnect(self):
         use_json = self.driver.__version__ >= "2.0.12" and \
             self.connection.server_version >= 90200
         if use_json:
@@ -165,7 +164,7 @@ class PostgrePsyco(Postgre):
 class PostgrePG8000(Postgre):
     drivers = ('pg8000',)
 
-    def _config_json(self):
+    def after_reconnect(self):
         if self.connection._server_version >= "9.2.0":
             self.dialect = self._get_json_dialect()(self)
             if self.driver.__version__ >= '1.10.2':
@@ -268,9 +267,8 @@ class JDBCPostgre(Postgre):
         self.connection.set_client_encoding('UTF8')
         self.execute('BEGIN;')
         self.execute("SET CLIENT_ENCODING TO 'UNICODE';")
-        self._config_json()
 
-    def _config_json(self):
+    def after_reconnect(self):
         use_json = self.connection.dbversion >= "9.2.0"
         if use_json:
             self.dialect = self._get_json_dialect()(self)

--- a/pydal/adapters/postgres.py
+++ b/pydal/adapters/postgres.py
@@ -140,7 +140,7 @@ class Postgre(with_metaclass(PostgreMeta, SQLAdapter)):
 class PostgrePsyco(Postgre):
     drivers = ('psycopg2',)
 
-    def after_reconnect(self):
+    def after_first_reconnect(self):
         use_json = self.driver.__version__ >= "2.0.12" and \
             self.connection.server_version >= 90200
         if use_json:
@@ -164,7 +164,7 @@ class PostgrePsyco(Postgre):
 class PostgrePG8000(Postgre):
     drivers = ('pg8000',)
 
-    def after_reconnect(self):
+    def after_first_reconnect(self):
         if self.connection._server_version >= "9.2.0":
             self.dialect = self._get_json_dialect()(self)
             if self.driver.__version__ >= '1.10.2':
@@ -268,7 +268,7 @@ class JDBCPostgre(Postgre):
         self.execute('BEGIN;')
         self.execute("SET CLIENT_ENCODING TO 'UNICODE';")
 
-    def after_reconnect(self):
+    def after_first_reconnect(self):
         use_json = self.connection.dbversion >= "9.2.0"
         if use_json:
             self.dialect = self._get_json_dialect()(self)

--- a/pydal/connection.py
+++ b/pydal/connection.py
@@ -133,9 +133,16 @@ class ConnectionPool(object):
         if callable(self._after_connection):
             self._after_connection(self)
         self.after_connection()
+        self.after_reconnect()
 
     def after_connection(self):
         #this it is supposed to be overloaded by adapters
+        pass
+
+    def after_reconnect(self):
+        #this it is supposed to be overloaded by adapters
+        #called after after_connection() and every time an idle connection
+        #is taken out of the connection pool.
         pass
 
     def reconnect(self):
@@ -164,6 +171,7 @@ class ConnectionPool(object):
                     try:
                         if self.check_active_connection:
                             self.test_connection()
+                        self.after_reconnect()
                         break
                     except:
                         pass


### PR DESCRIPTION
Some adapters are not properly initialized when they reuse idle connection from pool. In case of PostgreSQL, this actually results in unnecessary migrations of `json` fields back and forth between `TEXT` and `JSON` SQL types because the adapter will not check whether it can use dialects with native JSON support.

This pull request introduces new `after_reconnect()` adapter method which will be executed every time the connection is assigned to a new adapter object, no matter whether the connection was freshly created or reused from connection pool.