### PR TITLE
field.set_attributes(..) could return the instance

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1640,6 +1640,7 @@ class Field(Expression, Serializable):
 
     def set_attributes(self, *args, **attributes):
         self.__dict__.update(*args, **attributes)
+        return self
 
     def clone(self, point_self_references_to=False, **args):
         field = copy.copy(self)


### PR DESCRIPTION
Would let the code be  more straightforward -- example, when passing the "decorated" field to the function...
Now I have to   "scatter" the code in two places for each field...
https://github.com/web2py/web2py/issues/1595