### PR TITLE
Fixed misnamed regex in Oracle adapter

### DIFF
--- a/pydal/adapters/oracle.py
+++ b/pydal/adapters/oracle.py
@@ -37,7 +37,7 @@ class Oracle(SQLAdapter):
         command = self.filter_sql_command(args[0])
         i = 1
         while True:
-            m = self.oracle_fix.match(command)
+            m = self.cmd_fix.match(command)
             if not m:
                 break
             command = command[:m.start('clob')] + str(i) + \


### PR DESCRIPTION
This is a tiny PR that simply fixes a misnamed variable issue which at some point crept into the Oracle adaptor. 

This regular expression, which tests for CLOB (large text) columns:  
https://github.com/web2py/pydal/blob/master/pydal/adapters/oracle.py#L13

Is meant to be used here: 
https://github.com/web2py/pydal/blob/master/pydal/adapters/oracle.py#L40

But the name of the variable was changed back in the refactor at a6886a3f56e069970964431903d52cb7afd4f706, while its invocation was not.