### PR TITLE
two small bugfixes related to Oracle 

### DIFF
--- a/pydal/adapters/oracle.py
+++ b/pydal/adapters/oracle.py
@@ -37,7 +37,7 @@ class Oracle(SQLAdapter):
         command = self.filter_sql_command(args[0])
         i = 1
         while True:
-            m = self.oracle_fix.match(command)
+            m = self.cmd_fix.match(command)
             if not m:
                 break
             command = command[:m.start('clob')] + str(i) + \

--- a/pydal/dialects/oracle.py
+++ b/pydal/dialects/oracle.py
@@ -102,8 +102,9 @@ class OracleDialect(SQLDialect):
                 whr2 = whr + " AND w_row > %i" % lmin
             else:
                 whr2 = self.where('w_row > %i' % lmin)
-            return 'SELECT%s %s FROM (SELECT w_tmp.*, ROWNUM w_row FROM ' + \
-                '(SELECT %s FROM %s%s%s%s) w_tmp WHERE ROWNUM<=%i) %s%s%s%s;' \
+
+            return ('SELECT%s %s FROM (SELECT w_tmp.*, ROWNUM w_row FROM '
+                '(SELECT %s FROM %s%s%s%s) w_tmp WHERE ROWNUM<=%i) %s%s%s%s;') \
                 % (
                     dst, fields, fields, tables, whr, grp, order, lmax, tables,
                     whr2, grp, order)


### PR DESCRIPTION
I use web2py with Oracle at work, and after recently updating to the most recent master branch, I found two minor problems with Oracle support in PyDAL.

In adapters/oracle.py, it appears that a regex object that was once called `oracle_fix` was at some point renamed to `cmd_fix`. I made the substitution.

In dialects/oracle.py, when handling a `limitby`, two strings are being concatenated together, then %-substitutions applied. Due to order of operations, only the second part of the string was receiving the format substitutions, causing an error. I added parentheses around the string concatenation to address this. 