### PR TITLE
Fix LOB errors in Oracle

### DIFF
--- a/pydal/adapters/oracle.py
+++ b/pydal/adapters/oracle.py
@@ -74,6 +74,10 @@ class Oracle(SQLAdapter):
             id=id_name)
         )
 
+    def _select_aux_execute(self, sql):
+        self.execute(sql)
+        return self.fetchall()
+
     def fetchall(self):
         from ..drivers import cx_Oracle
         if any(x[1] == cx_Oracle.LOB or x[1] == cx_Oracle.CLOB


### PR DESCRIPTION
Using web2py to display records with CLOB datatypes, I received the error: 

`LOB variable no longer valid after subsequent fetch`

I found a version of `fetchall` that avoids this problem defined on the Oracle adapter in adapters/oracle.py, however, because the `_select_aux_execute` method in adapters/base.py (line 709) accesses `self.cursor.fetchall()`, the fixed version of `fetchall` was not being used. 

I overrode the `_select_aux_execute` method in the Oracle adapter and changed it to use the modified `fetchall`. This fixed the errors I was seeing in the web2py application.