### PR TITLE
Fix Table objects in common fields

### DIFF
--- a/pydal/base.py
+++ b/pydal/base.py
@@ -593,7 +593,7 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
         args_get = args.get
         common_fields = self._common_fields
         if common_fields:
-            fields = list(fields) + [f.clone() for f in common_fields]
+            fields = list(fields) + [f if isinstance(f, Table) else f.clone() for f in common_fields]
 
         table_class = args_get('table_class', Table)
         table = table_class(self, tablename, *fields, **args)


### PR DESCRIPTION
This fixes the problem of putting tables on common_fields and having lazy_define_table throw an exception because Table doesn't have a clone attribute.