### PR TITLE
A possible way to Fix #518

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1050,6 +1050,11 @@ class Table(Serializable, BasicStorage):
         return table_as_dict
 
     def with_alias(self, alias):
+        try:
+            if self._db[alias]._rname == self._rname:
+                return self._db[alias]
+        except AttributeError: # we never used this alias
+            pass
         other = copy.copy(self)
         other['ALL'] = SQLALL(other)
         other['_tablename'] = alias


### PR DESCRIPTION
Everyone please review. 

Should we store the aliases in the DAL, why is that done? That needs to be clarified.  
  
Given that we already do store the alias in the DAL it makes perfect sense to use it as a cache to solve the merge_tablemaps problem and even gain a bit of performance, however, why does that problem even exist.  
  
Another possible fix, if we want to stop storing aliases in the DAL, is for merge_tablemaps to check the tables _rname if the "is" check fails.
  
As I said many times before, the DAL seriously needs more comments explaining the "why" of the code.