### PR TITLE
Add Python 3 compatibility regarding __getitem__

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2770,6 +2770,8 @@ class Rows(BasicRows):
             fields=self.fields)
 
     def __getitem__(self, i):
+        if isinstance(i, slice):
+            return self.__getslice__(i.start, i.stop)
         row = self.records[i]
         keys = list(row.keys())
         if self.compact and len(keys) == 1 and keys[0] != '_extra':


### PR DESCRIPTION
Since `__getslice__` is deprecated since Python 3, slices now call `__getitem__` directly.  However, this has led to an AttributeError in `__getitem__`, as `'list' object has no attribute 'keys'`.  This should maintain backwards compatibility whilst fixing Python 3 support.