### PR TITLE
Closes #544: 'snapshot' is a depreciated option for pymongo versions > 3.7.0

### DIFF
--- a/pydal/adapters/mongo.py
+++ b/pydal/adapters/mongo.py
@@ -294,6 +294,8 @@ class Mongo(ConnectionConfigurationMixin, NoSQLAdapter):
             groupby=groupby, distinct=distinct, having=having)
         ctable = self.connection[tablename]
         modifiers = {'snapshot': snapshot}
+        if int(''.join(self.driver.version.split('.'))) > 370:
+            modifiers = {}
 
         if not expanded.pipeline:
             if limitby:


### PR DESCRIPTION
Removed the snapshot modifier if the driver version is bigger then 3.7.0