### PR TITLE
Set version number to 19.02

### DIFF
--- a/pydal/__init__.py
+++ b/pydal/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '17.11'
+__version__ = '19.02'
 
 from .base import DAL
 from .objects import Field


### PR DESCRIPTION
Changed version number to reduce missteps. It should be clear to developers what the current version is. Currently it's nowhere to be found, not in setup.py (which uses this version number), not in CHANGES (which is outdated) and not in README.md (which states that version 17.11 is the latest version on PyPi).

It would be great if this was released by the end of this month (that's why I changed the version number to 19.02).