### PR TITLE
 import urlopen from urllib2 not urllib

### DIFF
--- a/pydal/_compat.py
+++ b/pydal/_compat.py
@@ -27,8 +27,9 @@ if PY2:
     from email.MIMEMultipart import MIMEMultipart
     from email.MIMEText import MIMEText
     from email.Charset import add_charset, QP as charset_QP
-    from urllib import FancyURLopener, urlencode, urlopen
+    from urllib import FancyURLopener, urlencode
     from urllib import quote as urllib_quote, unquote as urllib_unquote, quote_plus as urllib_quote_plus
+    from urllib2 import urlopen
     from string import maketrans
     from types import ClassType
     import cgi


### PR DESCRIPTION
Otherwise gluon/tools.py fetch() is broken by this commit:
https://github.com/web2py/web2py/commit/f434ebec8a0c399944e039d8860c2d33ff9d3a32#diff-27d81880c098645f12c4d0f5afb17f1aR4635