### PR TITLE
Fix CSV export in Python 3

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2784,7 +2784,7 @@ class BasicRows(object):
             """
             if value is None:
                 return null
-            elif PY2 and isinstance(value, unicode):
+            elif isinstance(value, unicode):
                 return value.encode('utf8')
             elif isinstance(value, Reference):
                 return long(value)


### PR DESCRIPTION
In Python 3, the CSV writer still doesn't support Unicode, unfortunately.  This removes the check if we're running Python 2 and the value is a unicode string, fixing the following issue when exporting the database to a CSV:

```
Created by Massimo Di Pierro, Copyright 2007-2019                                                                                                                                                                  
Version 2.18.5-stable+timestamp.2019.04.08.04.22.03                                                                                                                                                                
Database drivers available: sqlite3, MySQLdb, mysqlconnector, psycopg2, pymongo, imaplib, pymysql, pyodbc, pg8000                                                                                                  
Traceback (most recent call last):                                                                                                                                                                                 
  File "/home/vinyldarkscratch/gooborg/gluon/shell.py", line 275, in run                                                                                                                                           
    execfile(startfile, _env)                                                                                                                                                                                      
  File "/home/vinyldarkscratch/gooborg/gluon/shell.py", line 41, in execfile                                                                                                                                       
    exec(code, global_vars, local_vars)                                                                                                                                                                            
  File "backup-db.py", line 1, in <module>                                                                                                                                                                         
    db.export_to_csv_file(open('backup.csv','w'))                                                                                                                                                                  
  File "/home/vinyldarkscratch/gooborg/gluon/packages/dal/pydal/base.py", line 852, in export_to_csv_file                                                                                                          
    ofile, *args, **kwargs)                                                                                                                                                                                        
  File "/home/vinyldarkscratch/gooborg/gluon/packages/dal/pydal/objects.py", line 2826, in export_to_csv_file                                                                                                      
    writer.writerow(row)                                                                                                                                                                                           
UnicodeEncodeError: 'ascii' codec can't encode character '\u0161' in position 11: ordinal not in range(128) 
```

Confirmed to function properly during export, as well as the proper unicode within the CSV, and seamless import in the SQLite database.