### PR TITLE
Allow reference to the field that is reference too

### DIFF
--- a/pydal/migrator.py
+++ b/pydal/migrator.py
@@ -80,7 +80,8 @@ class Migrator(object):
                                 referenced, table._tablename))
 
                 # must be PK reference or unique
-                if getattr(rtable, '_primarykey', None) and rfieldname in \
+                if not rfield.type.startswith(('reference', 'big-reference')) \
+                   and getattr(rtable, '_primarykey', None) and rfieldname in \
                    rtable._primarykey or rfield.unique:
                     ftype = types[rfield.type[:9]] % \
                         dict(length=rfield.length)

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -2677,7 +2677,7 @@ class TestQuoting(DALtest):
             t0.drop()
         else:
             t0.drop('cascade')
-            t1.drop()
+            t1.drop('cascade')
             t2.drop()
 
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -2670,8 +2670,8 @@ class TestQuoting(DALtest):
         self.assertEqual(result[0]['part_rev.id'], id_rev)
         self.assertEqual(result[0]['part_rev.part'], id)
 
-        if DEFAULT_URI.startswith('mssql'):
-            #there's no drop cascade in mssql
+        if DEFAULT_URI.startswith(('mssql', 'sqlite')):
+            #there's no drop cascade in mssql and it seems there is some problem in sqlite
             t2.drop()
             t1.drop()
             t0.drop()

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -2641,6 +2641,44 @@ class TestQuoting(DALtest):
             t2.drop()
             t3.drop()
             t4.drop()
+            
+    def testPKFK2(self):
+
+        # test reference to reference
+
+        db = self.connect(ignore_field_case=False)
+        if DEFAULT_URI.startswith('mssql'):
+            #multiple cascade gotcha
+            for key in ['reference','reference FK']:
+                db._adapter.types[key]=db._adapter.types[key].replace(
+                '%(on_delete_action)s','NO ACTION')
+
+        t0 = db.define_table('object', Field('id', 'id'))
+        t1 = db.define_table('part', Field('id', 'reference object'), primarykey = ['id'])
+        t2 = db.define_table('part_rev',
+                        Field('id', 'reference object'),
+                        Field('part', 'reference part'),
+                        Field('rev', 'integer'),
+                        primarykey = ['id']
+        )
+        id = db.object.insert()
+        db.part.insert(id = id)
+        id_rev = db.object.insert()
+        db.part_rev.insert(id = id_rev, part = id, rev = 0)
+        result = db(db.part_rev.part == db.part.id).select()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['part_rev.id'], id_rev)
+        self.assertEqual(result[0]['part_rev.part'], id)
+
+        if DEFAULT_URI.startswith('mssql'):
+            #there's no drop cascade in mssql
+            t2.drop()
+            t1.drop()
+            t0.drop()
+        else:
+            t0.drop('cascade')
+            t1.drop()
+            t2.drop()
 
 
 class TestTableAndFieldCase(unittest.TestCase):

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -2653,17 +2653,17 @@ class TestQuoting(DALtest):
                 db._adapter.types[key]=db._adapter.types[key].replace(
                 '%(on_delete_action)s','NO ACTION')
 
-        t0 = db.define_table('object', Field('id', 'id'))
-        t1 = db.define_table('part', Field('id', 'reference object'), primarykey = ['id'])
+        t0 = db.define_table('object_', Field('id', 'id'))
+        t1 = db.define_table('part', Field('id', 'reference object_'), primarykey = ['id'])
         t2 = db.define_table('part_rev',
-                        Field('id', 'reference object'),
+                        Field('id', 'reference object_'),
                         Field('part', 'reference part'),
                         Field('rev', 'integer'),
                         primarykey = ['id']
         )
-        id = db.object.insert()
+        id = db.object_.insert()
         db.part.insert(id = id)
-        id_rev = db.object.insert()
+        id_rev = db.object_.insert()
         db.part_rev.insert(id = id_rev, part = id, rev = 0)
         result = db(db.part_rev.part == db.part.id).select()
         self.assertEqual(len(result), 1)


### PR DESCRIPTION
fix issue #548
This patch is not perfect and has a limitation: referenced field must be `id` and  `integer`.
Solution for other field types requires storing underlying (real) type in the field object.   