### PR TITLE
Fixed defaults for DATE and DATETIME validators

### DIFF
--- a/pydal/validators.py
+++ b/pydal/validators.py
@@ -2330,7 +2330,7 @@ class IS_DATE(Validator):
             raise ValidationError(self.translator(self.error_message) % self.extremes)
 
     def formatter(self, value):
-        if value is None:
+        if value is None or value == '':
             return None
         format = self.format
         year = value.year
@@ -2397,7 +2397,7 @@ class IS_DATETIME(Validator):
             raise ValidationError(self.translator(self.error_message) % self.extremes)
 
     def formatter(self, value):
-        if value is None:
+        if value is None or value == '':
             return None
         format = self.format
         year = value.year


### PR DESCRIPTION
Dear Massimo and Giovanni, 

I was reviewing the changes that historically I had made to pydal as used in CrowdGrader, so that I can move to the newest web2py + pydal branch, and I found the following fix I had introduced.  The fix is used to consider an empty string equivalent to a missing value when formatting DATETIME and DATE fields.  

The fix was/is important to me because otherwise, if values in the db are an empty string, the code breaks.  I am not sure why I had some values in the database that were empty strings rather than NULL, but evidently I did. 

You might not like the change because it breaks reverse compatibility, but only in the sense that now, if a value in the database is an empty string, the code no longer breaks, and treats it as a missing date; to me this seems a reasonable choice, but of course you might disagree. 
Let me know if you plan to merge this, at your convenience; if not, I will subclass the DATE and DATETIME validators in my code to obtain the desired behavior. 

--Luca