### PR TITLE
Fix TypeError: unhashable type: 'Row'

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -108,6 +108,8 @@ class Row(BasicStorage):
     __int__ = lambda self: self.get('id')
 
     __long__ = lambda self: long(self.get('id'))
+    
+    __hash__ = lambda self: long(self.get('id'))
 
     __call__ = __getitem__
 


### PR DESCRIPTION
In python3, Row's lack of a __hash__ function prevents you from using Rows as a subquery:
`db(db.field.belongs(rows_object))` results in `TypeError: unhashable type: 'Row'`

Similar issue to #392