### PR TITLE
Fix relative paths for IS_URL() on python3

### DIFF
--- a/pydal/validators.py
+++ b/pydal/validators.py
@@ -1515,8 +1515,10 @@ def unicode_to_ascii_url(url, prepend_scheme):
 
     # if we still can't find the authority
     if not components.netloc:
-        raise Exception('No authority component found, ' +
-                        'could not decode unicode to US-ASCII')
+        # And it's not because the url is a relative url
+        if not url.startswith('/'):
+            raise Exception('No authority component found, ' +
+                            'could not decode unicode to US-ASCII')
 
     # We're here if we found an authority, let's rebuild the URL
     scheme = components.scheme


### PR DESCRIPTION
Fixes an issue identified migrating code to python 3.  Validating relative paths fails, as IS_URL()('/url') will throw an error because unicode_to_ascii_url can't find an authority.  When run in python 2, this path is never run, because strings, not unicode, were sent to IS_URL()

Perhaps this check should actually be done in IS_URL's validate(), but I suspect unicode_to_ascii_url has value for relative urls in encoding other parts of the path.