### PR TITLE
IS_IN_DB(..., multiple=(..., upper)) becomes inclusive

### DIFF
--- a/pydal/validators.py
+++ b/pydal/validators.py
@@ -651,7 +651,7 @@ class IS_IN_DB(Validator):
                 values = new_values
 
             if isinstance(self.multiple, (tuple, list)) and \
-                    not self.multiple[0] <= len(values) < self.multiple[1]:
+                    not self.multiple[0] <= len(values) <= self.multiple[1]:
                 raise ValidationError(self.translator(self.error_message))
             if self.theset:
                 if not [v for v in values if v not in self.theset]:


### PR DESCRIPTION
According to [docs](http://web2py.com/books/default/chapter/29/07/forms-and-validators#IS_IN_DB), the original design intention should be an inclusive lower and upper bound.

Please comment on whether we want to change the documentation or change the implementation. If we agree to change the implementation here, I'll go ahead to adjust the test cases too.