### PR TITLE
Fix " missing 1 required positional argument: 'record_id' " in w2p register_bare

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1993,7 +1993,7 @@ class Field(Expression, Serializable):
                 value = item.formatter(value)
         return value
 
-    def validate(self, value, record_id):
+    def validate(self, value, record_id=None):
         requires = self.requires
         if not requires or requires is DEFAULT:
             return ((value if value != self.map_none else None), None)


### PR DESCRIPTION
This PR fixes `TypeError(validate() missing 1 required positional argument: 'record_id')` when using `register_bare` in `web2py`.

Permalink to where is it internally used: https://github.com/web2py/web2py/blob/1ce316609a7a70c42dbd586c4a264193608880ba/gluon/tools.py#L2304