### PR TITLE
Fix sending bytes to uploadfs instead of a str

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1933,7 +1933,7 @@ class Field(Expression, Serializable):
             stream = BytesIO(to_bytes(data))
         elif self.uploadfs:
             # ## if file is on pyfilesystem
-            stream = self.uploadfs.open(name, 'rb')
+            stream = self.uploadfs.open(text_type(name), 'rb')
         else:
             # ## if file is on regular filesystem
             # this is intentionally a string with filename and not a stream


### PR DESCRIPTION
Basically just make `retrieve` call text_type on the name the same way `store` does fixes it.