### PR TITLE
Add support for python-tds

### DIFF
--- a/pydal/adapters/mssql.py
+++ b/pydal/adapters/mssql.py
@@ -157,11 +157,11 @@ class PyTDS(MSSQL):
             m = re.match(self.REGEX_URI, ruri)
             if not m:
                 raise SyntaxError("Invalid URI string in DAL: %s" % self.uri)
-            self.dsn = host
+            self.dsn = m.group("host")
             self.driver_args.update(
                 user=self.credential_decoder(m.group("user")),
                 password=self.credential_decoder(m.group("password")) or "",
-                database=m.group("db")
+                database=m.group("db"),
                 port=m.group("port") or "1433",
                 )
 

--- a/pydal/adapters/mssql.py
+++ b/pydal/adapters/mssql.py
@@ -15,7 +15,7 @@ class Slicer(object):
 
 class MSSQL(SQLAdapter):
     dbengine = "mssql"
-    drivers = ("pyodbc",)
+    drivers = ("pyodbc", "pytds")
 
     REGEX_DSN = "^.+$"
     REGEX_URI = (
@@ -142,6 +142,31 @@ class MSSQL3N(MSSQLN):
 class MSSQL4N(MSSQLN):
     pass
 
+@adapters.register_for("pytds")
+class PyTDS(MSSQL):
+
+    def _initialize_(self):
+        super(MSSQL, self)._initialize_()
+        ruri = self.uri.split("://", 1)[1]
+        if "@" not in ruri:
+            m = re.match(self.REGEX_DSN, ruri)
+            if not m:
+                raise SyntaxError("Invalid URI string in DAL")
+            self.dsn = m.group()
+        else:
+            m = re.match(self.REGEX_URI, ruri)
+            if not m:
+                raise SyntaxError("Invalid URI string in DAL: %s" % self.uri)
+            self.dsn = host
+            self.driver_args.update(
+                user=self.credential_decoder(m.group("user")),
+                password=self.credential_decoder(m.group("password")) or "",
+                database=m.group("db")
+                port=m.group("port") or "1433",
+                )
+
+    def connector(self):
+        return self.driver.connect(self.dsn, **self.driver_args)
 
 @adapters.register_for("vertica")
 class Vertica(MSSQL1):

--- a/pydal/base.py
+++ b/pydal/base.py
@@ -101,6 +101,7 @@ Supported DAL URI strings::
     'mssql2://web2py:none@A64X2/web2py_test' # alternate mappings
     'mssql3://web2py:none@A64X2/web2py_test' # better pagination (requires >= 2005)
     'mssql4://web2py:none@A64X2/web2py_test' # best pagination (requires >= 2012)
+    'pytds://user:password@server:port/database' # python-tds
     'oracle://username:password@database'
     'firebird://user:password@server:3050/database'
     'db2:ibm_db_dbi://DSN=dsn;UID=user;PWD=pass'

--- a/pydal/drivers.py
+++ b/pydal/drivers.py
@@ -171,3 +171,10 @@ try:
     DRIVERS["imaplib"] = imaplib
 except:
     pass
+
+try:
+    import pytds
+
+    DRIVERS["pytds"] = pytds
+except:
+    pass


### PR DESCRIPTION
Added `pytds` to the available drivers in pydal.drivers.
Added PyTDS as a subclass of MSSQL and registered it for pytds to override `_initialize_()` and `connect()` in pydal.adapters.mssql.

```python
from pydal import DAL
uri = 'pytds://user:password@server:port/database'
db = DAL(uri)
db.executesql('select 1 as one', as_dict=True)
[{'one': 1}]
```