### PR TITLE
Update db2.py

### DIFF
--- a/pydal/adapters/db2.py
+++ b/pydal/adapters/db2.py
@@ -27,7 +27,7 @@ class DB2(SQLAdapter):
         return rv
 
     def lastrowid(self, table):
-        self.execute("SELECT DISTINCT IDENTITY_VAL_LOCAL() FROM %s;" % table)
+        self.execute("SELECT DISTINCT IDENTITY_VAL_LOCAL() FROM %s;" % table._rname if table._rname else table)
         return long(self.cursor.fetchone()[0])
 
     def rowslice(self, rows, minimum=0, maximum=None):
@@ -35,6 +35,8 @@ class DB2(SQLAdapter):
             return rows[minimum:]
         return rows[minimum:maximum]
 
+    def test_connection(self):
+        self.execute("select * from sysibm.sysdummy1")
 
 @adapters.register_for("db2:ibm_db_dbi")
 class DB2IBM(DB2):
@@ -56,4 +58,6 @@ class DB2Pyodbc(DB2):
     drivers = ("pyodbc",)
 
     def connector(self):
-        return self.driver.connect(self.ruri, **self.driver_args)
+        conn = self.driver.connect(self.ruri, **self.driver_args)
+        conn.setencoding(encoding='utf-8')
+        return conn


### PR DESCRIPTION
Correct lastrowid function, taking in account existence of table._rname
Correct encoding issues setting 'utf-8' encoding in db2:pyodbc connector
Use correct SQL syntax (at least for DB2 for i) in test_connection function