### PR TITLE
included operations "container" and "in"

### DIFF
--- a/pydal/restapi.py
+++ b/pydal/restapi.py
@@ -378,6 +378,8 @@ class RestAPI(object):
                     "ge",
                     "le",
                     "startswith",
+                    "contains",
+                    "in"
                 ):
                     key_parts.append("eq")
                 is_negated = key_parts[0] == "not"

--- a/tests/restapi.py
+++ b/tests/restapi.py
@@ -313,6 +313,15 @@ class TestRestAPI(unittest.TestCase):
                 ]
             },
         )
+        self.assertEqual(
+            api.search("color", {"name.contains": "ee"}),
+            {"count": 1, "items": [{"id": 2, "name": "green"}]},
+        )
+        self.assertEqual(
+            api.search("color", {"name.in": "blue,green"}),
+            {"count": 2, "items": [{"id": 2, "name": "green"}, {"id": 3, "name": "blue"}]},
+        )
+
 
     def test_REST(self):
 


### PR DESCRIPTION
included operations "container" and "in" to complete their implementation