### PR TITLE
Drop PostGIS ST_AsGeoJSON gj_version parameter

### DIFF
--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -154,8 +154,7 @@ class PostgreDialect(SQLDialect):
         return rv
 
     def st_asgeojson(self, first, second, query_env={}):
-        return "ST_AsGeoJSON(%s,%s,%s,%s)" % (
-            second["version"],
+        return "ST_AsGeoJSON(%s,%s,%s)" % (
             self.expand(first, query_env=query_env),
             second["precision"],
             second["options"],
@@ -297,8 +296,7 @@ class PostgreDialectJSON(PostgreDialect):
         return "ST_AsText(%s)" % self.expand(first, query_env=query_env)
 
     def st_asgeojson(self, first, second, query_env={}):
-        return "ST_AsGeoJSON(%s,%s,%s,%s)" % (
-            second["version"],
+        return "ST_AsGeoJSON(%s,%s,%s)" % (
             self.expand(first, query_env=query_env),
             second["precision"],
             second["options"],

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1619,12 +1619,12 @@ class Expression(object):
 
     # GIS expressions
 
-    def st_asgeojson(self, precision=15, options=0, version=1):
+    def st_asgeojson(self, precision=15, options=0):
         return Expression(
             self.db,
             self._dialect.st_asgeojson,
             self,
-            dict(precision=precision, options=options, version=version),
+            dict(precision=precision, options=options),
             "string",
         )
 


### PR DESCRIPTION
In PostGIS 3.0.0, `ST_AsGeoJSON` doesn't accept any variant with explicit specification of GeoJSON version. This causes pydal queries to fail with errors like
```
ERROR:  function st_asgeojson(integer, geometry, integer, integer) does not exist at character 42
```

This PR drops the explicit `gj_version` parameter, while still retaining compatibility way back to PostGIS 1.5, where version 1 has been assumed implicitly (and making it consistent with Spatialite at the same time).

See documentation for PostGIS [version 3.0](https://postgis.net/docs/manual-3.0/ST_AsGeoJSON.html) vs. [version 2.5](https://postgis.net/docs/manual-2.5/ST_AsGeoJSON.html)