### PR TITLE
fix bug db.executesql()

### DIFF
--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -293,10 +293,13 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
                     value, f_itype, ftype, blob_decode
                 )
                 extras[colname] = value
-                new_column_match = self._regex_select_as_parser(colname)
-                if new_column_match is not None:
-                    new_column_name = new_column_match.group(1)
-                    new_row[new_column_name] = value
+                if not fields[j]:
+                    new_row[colname] = value
+                else:
+                    new_column_match = self._regex_select_as_parser(colname)
+                    if new_column_match is not None:
+                        new_column_name = new_column_match.group(1)
+                        new_row[new_column_name] = value
         #: add extras if needed (eg. operations results)
         if extras:
             new_row["_extra"] = extras

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -280,9 +280,11 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
                 #: additional parsing for 'id' fields
                 if ft == "id" and not cacheable:
                     self._add_operators_to_parsed_row(value, table, colset)
-                    self._add_reference_sets_to_parsed_row(
-                        value, table, tablename, colset
-                    )
+                    # table may be `nested_select` which doesn't have `_reference_by`
+                    if hasattr(table, '_reference_by'):
+                        self._add_reference_sets_to_parsed_row(
+                            value, table, tablename, colset
+                        )
             #: otherwise we set the value in extras
             else:
                 value = self.parse_value(

--- a/pydal/adapters/base.py
+++ b/pydal/adapters/base.py
@@ -280,15 +280,17 @@ class BaseAdapter(with_metaclass(AdapterMeta, ConnectionPool)):
                 #: additional parsing for 'id' fields
                 if ft == "id" and not cacheable:
                     self._add_operators_to_parsed_row(value, table, colset)
-                    # table may be `nested_select` which doesn't have `_reference_by`
+                    #: table may be 'nested_select' which doesn't have '_reference_by'
                     if hasattr(table, '_reference_by'):
                         self._add_reference_sets_to_parsed_row(
                             value, table, tablename, colset
                         )
             #: otherwise we set the value in extras
             else:
+                #: fields[j] may be None if only 'colnames' was specified in db.executesql()
+                f_itype, ftype = fields[j] and [fields[j]._itype, fields[j].type] or [None, None]
                 value = self.parse_value(
-                    value, fields[j]._itype, fields[j].type, blob_decode
+                    value, f_itype, ftype, blob_decode
                 )
                 extras[colname] = value
                 new_column_match = self._regex_select_as_parser(colname)

--- a/pydal/base.py
+++ b/pydal/base.py
@@ -914,7 +914,7 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
             if not colnames:
                 colnames = [f.sqlsafe for f in extracted_fields]
             else:
-                # extracted_fields is empty we should make it from colnames
+                #: extracted_fields is empty we should make it from colnames
                 # what 'col_fields' is for
                 col_fields = [] # [[tablename, fieldname], ....]
                 newcolnames = []
@@ -925,10 +925,6 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                     else:
                         t_f = None
                     if not extracted_fields:
-                        # if we're here, only 'colnames' was passed
-                        # and if so - tf is the name, not expression
-                        # so we should prefix it with ' AS ' to make parser treats it as colname
-                        tf = ' AS ' + tf
                         col_fields.append(t_f)
                     newcolnames.append(tf)
                 colnames = newcolnames

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -2236,12 +2236,23 @@ class TestExecuteSQL(DALtest):
 
         self.assertTrue(all(x in rtn[0].keys() for x in ["id", "b_field", "a_field"]))
         self.assertEqual(rtn[0].b_field, "bb1")
+        
         rtn = db.executesql(
             "select COUNT(*) from a_table",
             fields=[db.a_table.id.count()],
             colnames=["foo"],
         )
         self.assertEqual(rtn[0].foo, 1)
+        
+        # the same as the last 2 above, but with colnames only
+        rtn = db.executesql(
+            "select id, b_field, a_field, 7711 AS foo from a_table",
+            colnames=["a_table.id", "a_table.b_field", "a_table.a_field", "foo"],
+        )
+        
+        self.assertTrue(all(x in rtn[0].keys() for x in ["id", "b_field", "a_field", "foo"]))
+        self.assertEqual(rtn[0].foo, 7711)
+        
 
 
 class TestRNameTable(DALtest):

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -2246,12 +2246,12 @@ class TestExecuteSQL(DALtest):
         
         # the same as the last 2 above, but with colnames only
         rtn = db.executesql(
-            "select id, b_field, a_field, 7711 AS foo from a_table",
+            "select id, b_field, a_field, b_field AS foo from a_table",
             colnames=["a_table.id", "a_table.b_field", "a_table.a_field", "foo"],
         )
         
         self.assertTrue(all(x in rtn[0].keys() for x in ["id", "b_field", "a_field", "foo"]))
-        self.assertEqual(rtn[0].foo, 7711)
+        self.assertEqual(rtn[0].foo, "bb1")
         
 
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -2250,7 +2250,7 @@ class TestExecuteSQL(DALtest):
             colnames=["a_table.id", "a_table.b_field", "a_table.a_field", "foo"],
         )
         
-        self.assertTrue(all(x in rtn[0].keys() for x in ["id", "b_field", "a_field", "foo"]))
+        self.assertTrue(all(x in rtn[0].keys() for x in ["a_table", "foo"]))
         self.assertEqual(rtn[0].foo, "bb1")
         
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -2251,7 +2251,8 @@ class TestExecuteSQL(DALtest):
         )
         
         self.assertTrue(all(x in rtn[0].keys() for x in ["a_table", "foo"]))
-        self.assertEqual(rtn[0].foo, "bb1")
+        self.assertEqual(rtn[0].a_table.b_field, "bb1")
+        self.assertEqual(rtn[0].a_table.b_field, rtn[0].foo)
         
 
 


### PR DESCRIPTION
```python
subq = db(...).nested_select(t.f1.with_alias('foo'), t.f2.with_alias('bar')).with_alias('subq')
# below causes an error, because `subq` does not have `_reference_by`-attr
db.executesql('...',  fields = [subq.foo, subq.bar])  
```