### PR TITLE
add alias-property to Expression

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1616,6 +1616,11 @@ class Expression(object):
 
     def with_alias(self, alias):
         return Expression(self.db, self._dialect._as, self, alias, self.type)
+    
+    @property
+    def alias(self):
+        if self.op == self._dialect._as:
+            return self.second
 
     # GIS expressions
 


### PR DESCRIPTION
Sometimes it is necessary to check if the Expression/Field instance has an alias and get the value of it