### PR TITLE
store aliased tables separately

### DIFF
--- a/pydal/base.py
+++ b/pydal/base.py
@@ -469,6 +469,7 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
         self._LAZY_TABLES = {}
         self._lazy_tables = lazy_tables
         self._tables = SQLCallableList()
+        self._aliased_tables = dict()
         self._driver_args = driver_args
         self._adapter_args = adapter_args
         self._check_reserved = check_reserved
@@ -761,6 +762,9 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
         ) and key in object.__getattribute__(self, "_LAZY_TABLES"):
             tablename, fields, kwargs = self._LAZY_TABLES.pop(key)
             return self.lazy_define_table(tablename, *fields, **kwargs)
+        aliased = object.__getattribute__(self, "_aliased_tables").get(key, None)
+        if aliased:
+            return aliased
         return BasicStorage.__getattribute__(self, key)
 
     def __setattr__(self, key, value):

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1205,7 +1205,7 @@ class Table(Serializable, BasicStorage):
         if "id" in self and "id" not in other.fields:
             other["id"] = other[self.id.name]
         other._id = other[self._id.name]
-        self._db[alias] = other
+        self._db._aliased_tables[alias] = other
         return other
 
     def on(self, query):


### PR DESCRIPTION
This PR is related to web2py/py4web#167
With this fix (I hope) we can make aliased tables as thread local variable (as Fields property like `default` and so on)
Also, It would be nice to have a method to clear aliases