### PR TITLE
Remove the dependency on db in Field.store

### DIFF
--- a/pydal/base.py
+++ b/pydal/base.py
@@ -131,7 +131,6 @@ import threading
 import time
 import traceback
 import urllib
-from uuid import uuid4
 
 from ._compat import (
     PY2,
@@ -155,7 +154,7 @@ from .helpers.classes import (
     RecordDeleter,
     TimingHandler,
 )
-from .helpers.methods import hide_password, smart_query, auto_validators, auto_represent
+from .helpers.methods import hide_password, smart_query, auto_validators, auto_represent, uuidstr
 from .helpers.regex import REGEX_PYTHON_KEYWORDS, REGEX_DBNAME
 from .helpers.rest import RestParser
 from .helpers.serializers import serializers
@@ -289,7 +288,7 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
     validators = None
     representers = {}
     validators_method = default_validators
-    uuid = lambda x: str(uuid4())
+    uuid = uuidstr
     logger = logging.getLogger("pyDAL")
 
     Field = Field

--- a/pydal/helpers/methods.py
+++ b/pydal/helpers/methods.py
@@ -363,6 +363,8 @@ def auto_represent(field):
 def varquote_aux(name, quotestr="%s"):
     return name if REGEX_W.match(name) else quotestr % name
 
+def uuidstr():
+    return str(uuid.uuid4())
 
 def uuid2int(uuidv):
     return uuid.UUID(uuidv).int


### PR DESCRIPTION
The current `Field.store()` function relies on `db.uuid` and `field._tablename`, meaning user is unable to create a dedicated form with an `Field(type='upload')`.

This PR removes the dependency on `db` so that a file can be uploaded and saved in the file system without the knowledge of a database.