### PR TITLE
Missing "number(s)" translation

### DIFF
--- a/pydal/validators.py
+++ b/pydal/validators.py
@@ -4631,6 +4631,7 @@ class IS_STRONG(Validator):
                 numbers = "number"
                 if self.number > 1:
                     numbers = "numbers"
+                numbers = self.translator(number)
                 if not len(all_number) >= self.number:
                     failures.append(
                         self.translator("Must include at least %s %s")


### PR DESCRIPTION
When you're using IS_STRONG() in a different language the "number" of "numbers" text with IS_STRONG() is displayed in English.