### PR TITLE
fix multiple URIs

### DIFF
--- a/pydal/base.py
+++ b/pydal/base.py
@@ -508,6 +508,9 @@ class DAL(with_metaclass(MetaDAL, Serializable, BasicStorage)):
                         # self._adapter.ignore_field_case = ignore_field_case
                         if bigint_id:
                             self._adapter.dialect._force_bigints()
+                        # if there are multiple URIs to try in sequence, do not defer connection
+                        if len(uris) > 1:
+                            self._adapter.connector()
                         connected = True
                         break
                     except SyntaxError:


### PR DESCRIPTION
Fixes #620 
While it undoes the deferred connection @mdipierro built in (only for the case of multiple URI situations like mirroring), I can't see any other way of ensuring the URIs are tried in order if the first fails