### PR TITLE
Fix weird FileNotFoundError using relative path

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2065,6 +2065,7 @@ class Field(Expression, Serializable):
                     path = self.uploadfolder
                 elif self.db is not None and self.db._adapter.folder:
                     path = pjoin(self.db._adapter.folder, "..", "uploads")
+                    path = os.path.abspath(path)
                 else:
                     raise RuntimeError(
                         "you must specify a Field(..., uploadfolder=...)"
@@ -2149,6 +2150,7 @@ class Field(Expression, Serializable):
                 path = self.uploadfolder
             else:
                 path = pjoin(self.db._adapter.folder, "..", "uploads")
+                path = os.path.abspath(path)
         if self.uploadseparate:
             t = m.group("table")
             f = m.group("field")


### PR DESCRIPTION
Fix weird FileNotFoundError using relative paths that happens if the file is in a microsoft windows shared folder.