### PR TITLE
Use base 64 for upload file name encoding

### DIFF
--- a/pydal/helpers/regex.py
+++ b/pydal/helpers/regex.py
@@ -8,7 +8,7 @@ REGEX_W = re.compile(r"^\w+$")
 REGEX_TABLE_DOT_FIELD = re.compile(r"^(\w+)\.(\w+)$")
 REGEX_TABLE_DOT_FIELD_OPTIONAL_QUOTES = r'^"?(\w+)"?\."?(\w+)"?$'
 REGEX_UPLOAD_PATTERN = (
-    r"(?P<table>\w+)\.(?P<field>\w+)\.(?P<uuidkey>[\w-]+)(\.(?P<name>\w+))?\.\w+$"
+    r"(?P<table>\w+)\.(?P<field>\w+)\.(?P<uuidkey>[\w-]+)(\.(?P<name>\S+))?\.\w+$"
 )
 REGEX_UPLOAD_CLEANUP = "['\"\\s;]+"
 REGEX_UNPACK = r"(?<!\|)\|(?!\|)"

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -1621,7 +1621,7 @@ class Expression(object):
 
     def with_alias(self, alias):
         return Expression(self.db, self._dialect._as, self, alias, self.type)
-    
+
     @property
     def alias(self):
         if self.op == self._dialect._as:
@@ -2034,7 +2034,7 @@ class Field(Expression, Serializable):
         m = re.search(REGEX_UPLOAD_EXTENSION, filename)
         extension = m and m.group(1) or "txt"
         uuid_key = uuidstr().replace("-", "")[-16:]
-        encoded_filename = to_unicode(base64.b64encode(to_bytes(filename)))
+        encoded_filename = to_unicode(base64.urlsafe_b64encode(to_bytes(filename)))
         # Fields that are not bound to a table use "tmp" as the table name
         tablename = getattr(self, "_tablename", "tmp")
         newfilename = "%s.%s.%s.%s" % (
@@ -2134,8 +2134,8 @@ class Field(Expression, Serializable):
         try:
             try:
                 filename = to_unicode(base64.b16decode(m.group("name"), True)) # Legacy file encoding is base 16 lowercase
-            except binascii.Error: 
-                filename = to_unicode(base64.b64decode(m.group("name"))) # New encoding is base 64
+            except binascii.Error:
+                filename = to_unicode(base64.urlsafe_b64decode(m.group("name"))) # New encoding is base 64
             filename = re.sub(REGEX_UPLOAD_CLEANUP, "_", filename)
         except (TypeError, AttributeError):
             filename = name

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -29,7 +29,6 @@ from ._compat import (
     copyreg,
     reduce,
     to_bytes,
-    to_native,
     to_unicode,
     long,
     text_type,


### PR DESCRIPTION
Hello,

This is an update PR of #640 . I have changed base 64 to base 64 safe url to avoid the '/' in encoding that  conflict with windows filename restrictions.  In addition I have update the regex for file name encoding, to allow the base 64 special characters encoding ones ('_','-' and '=' for padding).   