### PR TITLE
Fix specifying driver for mysql connection

### DIFF
--- a/pydal/adapters/mysql.py
+++ b/pydal/adapters/mysql.py
@@ -4,6 +4,9 @@ from ..utils import split_uri_args
 from . import adapters, with_connection
 
 
+@adapters.register_for("mysql:mysqlconnector")
+@adapters.register_for("mysql:pymysql")
+@adapters.register_for("mysql:MySQLdb")
 @adapters.register_for("mysql")
 class MySQL(SQLAdapter):
     dbengine = "mysql"


### PR DESCRIPTION
DAL constructor connection string, allows specifying driver to be used to connect to database, when several are available, but this was failing for MySql case. E.g. mysql:pymysql:
Now can be given any of the supported drivers: MySQLdb, pymysql, mysqlconnector.
If no driver is given (just mysql:) the behaviour remains unchanged, so will use the first available of the list.