### PR TITLE
Fixes to oracle.py

### DIFF
--- a/pydal/adapters/oracle.py
+++ b/pydal/adapters/oracle.py
@@ -14,11 +14,10 @@ class Oracle(SQLAdapter):
     dbengine = "oracle"
     drivers = ("cx_Oracle",)
 
-    cmd_fix = re.compile("[^']*('[^']*'[^']*)*\:(?P<clob>(C|B)LOB\('([^']+|'')*'\))")
-
-    def _initialize_(self, do_connect):
-        super(Oracle, self)._initialize_(do_connect)
+    def _initialize_(self):
+        super(Oracle, self)._initialize_()
         self.ruri = self.uri.split("://", 1)[1]
+        self.REGEX_CLOB = re.compile("[^']*('[^']*'[^']*)*\:(?P<clob>(C|B)LOB\('([^']+|'')*'\))")
         if "threaded" not in self.driver_args:
             self.driver_args["threaded"] = True
         # set character encoding defaults


### PR DESCRIPTION
Fixes for the following errors:
~~~python
from gluon.dal import DAL
db=DAL('oracle://***/***@****:1521/***',auto_import=True, db_codec='latin-1')
~~~
Traceback (most recent call last):
  File "*****/web2py/gluon/packages/dal/pydal/base.py", line 507, in __init__
    self._adapter = adapter(**kwargs)
  File "****/web2py/gluon/packages/dal/pydal/adapters/__init__.py", line 41, in __call__
    obj = super(AdapterMeta, cls).__call__(*args, **kwargs)
  File "****/web2py/gluon/packages/dal/pydal/adapters/base.py", line 424, in __init__
    super(SQLAdapter, self).__init__(*args, **kwargs)
  File "*****/web2py/gluon/packages/dal/pydal/adapters/base.py", line 86, in __init__
    self._initialize_()
TypeError: _initialize_() missing 1 required positional argument: 'do_connect'

~~~python
row = db.executesql(sql, as_dict=True)
~~~
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/****/web2py/gluon/packages/dal/pydal/base.py", line 878, in executesql
    adapter.execute(query)
  File "/****/web2py/gluon/packages/dal/pydal/adapters/__init__.py", line 69, in wrap
    return f(*args, **kwargs)
  File "/****/web2py/gluon/packages/dal/pydal/adapters/oracle.py", line 51, in execute
    i = 1
AttributeError: 'Oracle' object has no attribute 'REGEX_CLOB'