### PR TITLE
Fix "TypeError: '<' not supported between instances of 'int' and 'str…

### DIFF
--- a/pydal/connection.py
+++ b/pydal/connection.py
@@ -119,7 +119,7 @@ class ConnectionPool(object):
             try:
                 GLOBAL_LOCKER.acquire()
                 pool = ConnectionPool.POOLS[self.uri]
-                if len(pool) < self.pool_size:
+                if len(pool) < int(self.pool_size):
                     pool.append(self.connection)
                     really = False
             finally:


### PR DESCRIPTION
When using web2py/pydal with python3 pydal breaks with the following message:
"TypeError: '<' not supported between instances of 'int' and 'str". 

This does not happen with python 2 as it apparently automatically casts self.pool_size to appropriate type. 