### PR TITLE
Only use TextIOWrapper if needed

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -254,7 +254,7 @@ class Row(BasicStorage):
 
 
 def pickle_row(s):
-     return Row, ({k: v for k, v in s.items() if not callable(v)},)
+    return Row, ({k: v for k, v in s.items() if not callable(v)},)
 
 
 copyreg.pickle(Row, pickle_row)

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -254,7 +254,7 @@ class Row(BasicStorage):
 
 
 def pickle_row(s):
-    return Row, ({k: v for k, v in s.items() if not callable(v)},)
+     return Row, (dict(s),)
 
 
 copyreg.pickle(Row, pickle_row)

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -100,7 +100,7 @@ DEFAULT_REGEX = {
 
 def csv_reader(utf8_data, dialect=csv.excel, encoding="utf-8", **kwargs):
     """like csv.reader but allows to specify an encoding, defaults to utf-8"""
-    csv_reader = csv.reader(TextIOWrapper(utf8_data,encoding), dialect=dialect, **kwargs)
+    csv_reader = csv.reader(utf8_data if isinstance(utf8_data,TextIOWrapper) else TextIOWrapper(utf8_data,encoding), dialect=dialect, **kwargs)
     for row in csv_reader:
         yield [to_unicode(cell, encoding) for cell in row]
 

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -254,7 +254,7 @@ class Row(BasicStorage):
 
 
 def pickle_row(s):
-     return Row, (dict(s),)
+     return Row, ({k: v for k, v in s.items() if not callable(v)},)
 
 
 copyreg.pickle(Row, pickle_row)

--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -100,7 +100,9 @@ DEFAULT_REGEX = {
 
 def csv_reader(utf8_data, dialect=csv.excel, encoding="utf-8", **kwargs):
     """like csv.reader but allows to specify an encoding, defaults to utf-8"""
-    csv_reader = csv.reader(utf8_data if isinstance(utf8_data,TextIOWrapper) else TextIOWrapper(utf8_data,encoding), dialect=dialect, **kwargs)
+    csv_reader = csv.reader(utf8_data if isinstance(utf8_data,TextIOWrapper) 
+                                      else TextIOWrapper(utf8_data,encoding), 
+                            dialect=dialect, **kwargs)
     for row in csv_reader:
         yield [to_unicode(cell, encoding) for cell in row]
 


### PR DESCRIPTION
Fix the exception when TextIOWrapper is used twice. Happens if IO stream have to be converted before, for instance when CSV file are uploaded dynamically. See issue #671 for more details.