### PR TITLE
Fix Tags import to import from tools and not utils

### DIFF
--- a/tests/tags.py
+++ b/tests/tags.py
@@ -1,6 +1,6 @@
 import unittest
 from pydal import DAL, Field
-from pydal.utils.tags import Tags
+from pydal.tools.tags import Tags
 
 
 class TestTags(unittest.TestCase):


### PR DESCRIPTION
This import not being correct is causing the pydal tests to fail.   
  
PS: Why are we merging test breaking changes without changing the tests?