### PR TITLE
Fix IS_IN_DB with multiple=True for single value

### DIFF
--- a/pydal/validators.py
+++ b/pydal/validators.py
@@ -705,7 +705,7 @@ class IS_IN_DB(Validator):
             ):
                 raise ValidationError(self.translator(self.error_message))
             if self.theset:
-                if not [v for v in values if v not in self.theset]:
+                if not [v for v in values if str(v) not in self.theset]:
                     return values
             else:
 


### PR DESCRIPTION
When using a py4web grid with Select Widget and choosing only one option while multiple = True, the form gives a validation error.
This is because in this case, the `value` passed to validate is an integer, while `theset` is a list of strings. By explicitly converting `v` to a string, saving the multiple select works again. I hope this does not break any other logic in the module.