### PR TITLE
InDBMigrator - Sqlite Placeholder Correction

### DIFF
--- a/pydal/helpers/classes.py
+++ b/pydal/helpers/classes.py
@@ -547,7 +547,8 @@ class DatabaseStoredFile:
             self.db.executesql(
                 "DELETE FROM web2py_filesystem WHERE path='%s'" % self.filename
             )
-            query = "INSERT INTO web2py_filesystem(path,content) VALUES (%s, %s)"
+            placeholder = "?" if self.db._adapter.dbengine == "sqlite" else "%s" 
+            query = "INSERT INTO web2py_filesystem(path,content) VALUES (%(placeholder)s, %(placeholder)s)" % {"placeholder": placeholder}
             args = (self.filename, self.data)
             self.db.executesql(query, args)
             self.db.commit()


### PR DESCRIPTION
Correcting the placeholder value relating to the InDBMigrator logic for web2py_filesystem. The sqlite adapter uses a "?" as a placeholder, whereas mysql and postgresql use "%s" as the placeholder, so this needs to be dynamic depending on the database being used.

[https://docs.python.org/3/library/sqlite3.html#how-to-use-placeholders-to-bind-values-in-sql-queries](https://docs.python.org/3/library/sqlite3.html#how-to-use-placeholders-to-bind-values-in-sql-queries)

Resolves #701