### PR TITLE
Fix license file name in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE
+include LICENSE.txt
 include AUTHORS
 include CHANGES
 recursive-include tests *


### PR DESCRIPTION
This is causing the license file to be missing in sdists.