### PR TITLE
use `object.__setattr__`  to set attribute on `Table`

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -723,7 +723,7 @@ class Table(Serializable, BasicStorage):
             elif isinstance(value, FieldMethod):
                 value.bind(self, str(key))
                 self._virtual_methods.append(value)
-            self.__dict__[str(key)] = value
+            object.__setattr__(self, str(key), value)
 
     def __setattr__(self, key, value):
         if key[:1] != "_" and key in self:


### PR DESCRIPTION
This allows to use `ThreadsafeVariable` for `_common_filter `