### PR TITLE
Fix for validate_and_insert() and validate_and_update() in restapi.py

### DIFF
--- a/pydal/restapi.py
+++ b/pydal/restapi.py
@@ -232,13 +232,13 @@ class RestAPI(object):
             return self.search(tablename, get_vars)
         elif method == "POST":
             table = self.db[tablename]
-            return table.validate_and_insert(**post_vars).as_dict()
+            return table.validate_and_insert(**post_vars)  # .as_dict()
         elif method == "PUT":
             id = id or post_vars["id"]
             if not id:
                 raise InvalidFormat("No item id specified")
             table = self.db[tablename]
-            data = table.validate_and_update(id, **post_vars).as_dict()
+            data = table.validate_and_update(id, **post_vars)  # .as_dict()
             if not data.get("errors") and not data.get("updated"):
                 raise NotFound("Item not found")
             return data


### PR DESCRIPTION
When trying to create or edit an entry in the _dashboard/database grid, the .as_dict() method is throwing an error 500 (AttributeError: 'dict' object has no attribute 'as_dict')

I tested this with py4web version 1.20230416.3