### PR TITLE
Add build-system to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
       "Operating System :: OS Independent",
 ]
 
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [project.urls]
 "Homepage" = "https://github.com/web2py/pydal"
 "Bug Tracker" = "https://github.com/web2py/pydal/issues"


### PR DESCRIPTION
According to [PEP-518](https://peps.python.org/pep-0518/#build-system-table), we need a `build-system` table in the `pyproject.toml` for it to work for a setuptools build back-end