### PR TITLE
Added legacy-cgi as dependency in order to support Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
       "Operating System :: OS Independent",
 ]
 
+dependencies = [
+    "legacy-cgi; python_version >= '3.13'"
+]
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Since Python 3.13, the builtin `cgi` module (which pydal uses) was removed.
The easiest way to fix this, is to include [jackrosenthal/legacy-cgi](https://github.com/jackrosenthal/legacy-cgi) ([pypi: legacy-cgi](https://pypi.org/project/legacy-cgi/)) as a dependency.

I saw there weren't any other dependencies yet, so I would understand if adding one is not an ideal solution. It would however be great to use pydal in Python 3.13 and beyond. I did not see any other issues or pull requests mentioning this issue. 

I ran `python3.13 -m unittest` and they all seem to still run (`OK (skipped=10)` just like with `python3.11`)