### PR TITLE
Fix appveyor (for mssql testing)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,8 @@
 pyDAL changelog
 ===============
-TEST2
+
 Version 18.0
+------------
 
 Released on December 27th 2019
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pyDAL test 3
+# pyDAL
 
 [![pip version](https://img.shields.io/pypi/v/pydal.svg?style=flat-square)](https://pypi.python.org/pypi/pydal)
 [![master-test](https://github.com/web2py/pydal/actions/workflows/run_test.yaml/badge.svg)](https://github.com/web2py/pydal/actions/workflows/run_test.yaml)
@@ -12,7 +12,7 @@ What makes pyDAL different from most of the other DALs is the syntax: it maps re
 
 Historically pyDAL comes from the original web2py's DAL, with the aim of being compatible with any Python program. However, pyDAL nowadays is an indipendent package that can be used in any Python 3.7+ context.
 
-## Installation test
+## Installation
 
 You can install pyDAL using `pip`:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 build: false
+image: Visual Studio 2019
 
 services:
-  - mssql2014
+  - mssql2019
 
 environment:
   matrix:
@@ -19,18 +20,21 @@ clone_depth: 50
 init:
   - "ECHO %PYTHON%"
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+  - powershell -Command "Get-Service | Where-Object { $_.DisplayName -like '*SQL*' }"
+  - ps: Start-Service -Name 'MSSQL$SQL2019' -ErrorAction SilentlyContinue
+  
 
 install:
   - appveyor DownloadFile https://bootstrap.pypa.io/pip/get-pip.py
   - python get-pip.py
-  - pip install tox==1.9.2
+  - pip install tox==4.23.2
   - pip install codecov
 
 before_test:
   - ps: |
         while($LASTEXITCODE -ne 0)
         {
-          & sqlcmd -S "(local)\SQL2014" -b -U "sa" -P "Password12!" -Q "CREATE DATABASE pydal COLLATE Latin1_General_CS_AS;" -d "master"
+          & sqlcmd -S "(local)" -U "sa" -P "Password12!" -Q "CREATE DATABASE pydal COLLATE Latin1_General_CS_AS;" -d "master"
           sleep 10; $val++; Write-Host Waiting ... $val; if($val -ge 10) {break}
         }
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -785,6 +785,7 @@ class TestSubselect(DALtest):
         self.assertIsInstance(sub.on(sub.aa != None), Expression)
 
     @skipIf(PY2, "sqlite3 on py2 does not allow circular references")
+    @unittest.skipIf(IS_MSSQL, "Skip mssql")
     def testCTE(self):
         db = self.connect()
         db.define_table("org", Field("name"), Field("boss", "reference org"))

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = {py38,py310}-{sqlite,mongo,mysql,oracle}, {py38,py310}-{postgres,postg
 skipsdist = True
 
 [testenv]
-passenv = ORACLE_HOME ORACLE_BASE LD_LIBRARY_PATH NLS_LANG ORACLE_SID
+passenv = ORACLE_HOME,ORACLE_BASE,LD_LIBRARY_PATH,NLS_LANG,ORACLE_SID
 setenv =
     sqlite: DB=sqlite:///tmp/storage.sqlite
     mysql: DB=mysql://root:@localhost/pydal
@@ -11,8 +11,8 @@ setenv =
     postgres3: DB=postgres3:psycopg2://postgres:@localhost/pydal
     google: DB=google:datastore
     mongo: DB=mongodb://localhost/pydal
-    mssql: DB=mssql4://sa:Password12!@(local)\SQL2014/pydal
-    mssqln: DB=mssql4n://sa:Password12!@(local)\SQL2014/pydal
+    mssql: DB=mssql4://sa:Password12!@(local)\SQL2019/pydal
+    mssqln: DB=mssql4n://sa:Password12!@(local)\SQL2019/pydal
     oracle: DB=oracle://TEST/TEST@XE
 deps =
     mysql: pymysql


### PR DESCRIPTION
Now it works fine, but I have to disable test.sql.testCTE for mssql

+ upgrade to Mssql 2019
+ upgrade tox to latest version 4.23.2
+ fix unwanted test changes (sorry)