### PR TITLE
Include already existing JSON operators in other postgres adapters and fix contains for bigint[]

### DIFF
--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -379,14 +379,8 @@ class PostgreDialectArrays(PostgreDialect):
         return super(PostgreDialectArrays, self).eq(first, second, query_env)
 
 
-class PostgreDialectArraysJSON(PostgreDialectArrays):
-    @sqltype_for("json")
-    def type_json(self):
-        return "JSON"
-
-    @sqltype_for("jsonb")
-    def type_jsonb(self):
-        return "JSONB"
+class PostgreDialectArraysJSON(PostgreDialectArrays, PostgreDialectJSON):
+    pass
 
 
 @dialects.register_for(PostgreBoolean)
@@ -396,11 +390,5 @@ class PostgreDialectBoolean(PostgreDialectArrays):
         return "BOOLEAN"
 
 
-class PostgreDialectBooleanJSON(PostgreDialectBoolean):
-    @sqltype_for("json")
-    def type_json(self):
-        return "JSON"
-
-    @sqltype_for("jsonb")
-    def type_jsonb(self):
-        return "JSONB"
+class PostgreDialectBooleanJSON(PostgreDialectBoolean, PostgreDialectJSON):
+    pass

--- a/pydal/dialects/postgre.py
+++ b/pydal/dialects/postgre.py
@@ -356,11 +356,11 @@ class PostgreDialectArrays(PostgreDialect):
 
     def contains(self, first, second, case_sensitive=True, query_env={}):
         if first.type.startswith("list:"):
-            f = self.expand(second, "string", query_env=query_env)
+            f = self.expand(second, "string" if first.type == 'list:string' else "integer", query_env=query_env)
             s = self.any(first, query_env)
-            if case_sensitive is True:
-                return self.eq(f, s)
-            return self.ilike(f, s, escape="\\", query_env=query_env)
+            if not case_sensitive and first.type == 'list:string':
+                return self.ilike(f, s, escape="\\", query_env=query_env)
+            return self.eq(f, s)
         return super(PostgreDialectArrays, self).contains(
             first, second, case_sensitive=case_sensitive, query_env=query_env
         )


### PR DESCRIPTION
- Multiple postgres adapters were supporting JSON/JSONB columns, but were missing out on JSON operators defined in PostgreDialectJSON dialect
- Contains for bigint[] was using ilike incorrecly