### PR TITLE
Fix querybuilder trying to parse to last doublequote

### DIFF
--- a/pydal/querybuilder.py
+++ b/pydal/querybuilder.py
@@ -88,7 +88,7 @@ class QueryBuilder:
     # regex matching field names, and
     re_token = re.compile(r"^(\w+)\s*(.*)$")
     # regex matching a value or quoted value
-    re_value = re.compile(r'^((?:")[^"]*(?:[\]["][^"]*)*(?:")|[^ ,]*)\s*(.*)$')
+    re_value = re.compile(r'^((?:")[^"]*(?:[\]["][^"]*)*?(?:")|[^ ,]*)\s*(.*)$')
     # regex matching repeated spaces
     re_spaces = re.compile(r"\s+")
 


### PR DESCRIPTION
Before:

`id > "5" and id < "10"` -> `5" and id < "10: Enter an integer greater than or equal to 0`

After:

works without error