### PR TITLE
Fix: IS_IN_SET with multiple values

### DIFF
--- a/pydal/validators.py
+++ b/pydal/validators.py
@@ -590,7 +590,7 @@ class IS_IN_SET(Validator):
                     raise ValidationError(self.translator(self.error_message))
         else:
             values = [value]
-        strkeys = map(str, valuemap)
+        strkeys = set(map(str, valuemap))
         failures = [x for x in values if not str(x) in strkeys]
         if failures and self.theset:
             raise ValidationError(self.translator(self.error_message))


### PR DESCRIPTION
strkeys is a map object (a lazy iterator in Python 3, unlike Python 2 where it returned a list). This means If you try to check membership with **in**, it exhausts the iterator progressively, this leads to very funny errors and sometimes the validator would seem to work correctly depending on the order.