### PR TITLE
remove `FancyURLopener` so pydal works in Python 3.14

### DIFF
--- a/pydal/_compat.py
+++ b/pydal/_compat.py
@@ -111,7 +111,7 @@ else:
     from urllib.parse import unquote
     from urllib.parse import unquote as urllib_unquote
     from urllib.parse import urlencode
-    from urllib.request import FancyURLopener, urlopen
+    from urllib.request import urlopen
     from xmlrpc.client import ProtocolError
 
     hashlib_md5 = lambda s: hashlib.md5(bytes(s, "utf8"))


### PR DESCRIPTION
Today, Python 3.14 was released. This version removes `urllib.FancyURLopener` which was imported by _compat but not used by pydal.
https://docs.python.org/3.14/whatsnew/3.14.html#id12

I ran `make test` and the result seemed good (`OK (skipped=10)`)