### PR TITLE
Row __contains__ allowing membership checking of aliased fields in _extra

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -186,6 +186,12 @@ class Row(BasicStorage):
 
         raise KeyError(key)
 
+    def __contains__(self, k):
+        key = str(k)
+
+        _extra = BasicStorage.get(self, "_extra", None)
+        return (_extra is not None and k in _extra) or BasicStorage.__contains__(self, key)
+
     def __repr__(self):
         return "<Row %s>" % self.as_dict(custom_types=[LazySet])
 


### PR DESCRIPTION
alias should be first class citizens in a Row object, as this one gets all the alias with the different transformations of columns in select.
This allows for this type of select:
```
db(db.my_table.id > 0).select(db.my_table.my_date.year().with_alias('year'), ...)
```
To be processed at the row level like this:
```
if 'year' in row:
    print('in the year 2000....')
```