### PR TITLE
Revert "Fix: #746"

### DIFF
--- a/pydal/objects.py
+++ b/pydal/objects.py
@@ -2539,11 +2539,7 @@ class Field(Expression, Serializable):
         if not self._db or tablename not in self._db:
             # The table being referenced is not defined yet
             return None
-        try:
-            table = self._db[tablename]
-        except AttributeError:
-            # The table being referenced is lazy and not available yet
-            return None
+        table = self._db[tablename]
         return table[fieldname] if fieldname else table._id
 
     def referenced_table(self):


### PR DESCRIPTION
Reverts web2py/pydal#749

We already fixed it in 

```
if not self._db or tablename not in self._db:
             # The table being referenced is not defined yet
             return None
```