### PR TITLE
Add support for Microsoft's mssql-python driver

### DIFF
--- a/pydal/base.py
+++ b/pydal/base.py
@@ -101,6 +101,7 @@ Supported DAL URI strings::
     'mssql2://web2py:none@A64X2/web2py_test' # alternate mappings
     'mssql3://web2py:none@A64X2/web2py_test' # better pagination (requires >= 2005)
     'mssql4://web2py:none@A64X2/web2py_test' # best pagination (requires >= 2012)
+    'mssqlpython://user:password@server:port/database' # mssql with mssql-python driver
     'pytds://user:password@server:port/database' # python-tds
     'pymssql://user:password@server:port/database' # python-pymssql
     'oracle://username:password@database'

--- a/pydal/drivers.py
+++ b/pydal/drivers.py
@@ -196,3 +196,10 @@ try:
     DRIVERS["pymssql"] = pymssql
 except:
     pass
+
+try:
+    import mssql_python
+
+    DRIVERS["mssql-python"] = mssql_python
+except:
+    pass


### PR DESCRIPTION
This pull request adds support for Microsoft's official `mssql-python` driver to the DAL, enabling modern SQL Server features, improved security, and advanced authentication options. The changes include a new adapter class, updated driver registration, and documentation for the new URI scheme.

**Microsoft mssql-python driver integration:**

* Added `"mssql-python"` to the list of supported drivers in the `MSSQL` adapter, and registered the driver in `pydal/drivers.py` for dynamic import. [[1]](diffhunk://#diff-b835fc4cbeb2191345ec986b4a5bb3b2fa1cc2119752163bf769a687aa6bb366L19-R19) [[2]](diffhunk://#diff-5e2e8a4833dfa1ee18339d92fa74073ec04e9019d823a8a42b963572b138941bR199-R205)
* Introduced a new `MSSQLPython` adapter class in `pydal/adapters/mssql.py` that supports the `mssql-python` driver, modern OFFSET/FETCH pagination, encryption by default, and Microsoft Entra ID authentication methods. This includes detailed URI parsing and parameter handling for features like encryption, trust server certificate, and multiple authentication modes.
* Documented the new `mssqlpython://` URI scheme and its parameters in both `pydal/base.py` and the new adapter's docstring, providing examples for various authentication and encryption scenarios. [[1]](diffhunk://#diff-530652545e1cf7269ec52c278ea77759674615df70ae0dbe558bafe0b60f818eR104) [[2]](diffhunk://#diff-b835fc4cbeb2191345ec986b4a5bb3b2fa1cc2119752163bf769a687aa6bb366R236-R348)