### PR TITLE
Fix tests - make them run in MSSQL and Postgres

### DIFF
--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -17,6 +17,21 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: pydal_test
+          POSTGRES_PASSWORD: pydal_test
+          POSTGRES_DB: pydal_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -29,6 +44,11 @@ jobs:
             python -m pip install --upgrade pip
             ls -l
             python -m pip install -e .[test]
-      - name: Test
+      - name: Test (SQLite)
+        run: |
+            python -m unittest tests
+      - name: Test (PostgreSQL)
+        env:
+          DB: postgres://pydal_test:pydal_test@localhost:5432/pydal_test
         run: |
             python -m unittest tests

--- a/TODO.md
+++ b/TODO.md
@@ -55,16 +55,29 @@ what (small) corners remain.
 - Removes the `self.compiler = None` workaround that previously forced
   all MSSQL queries through the legacy dialect path.
 
+### 6. Postgres backend verified + `LIKE` on non-text fields — done
+
+- The full suite now runs against PostgreSQL (Docker, CI service in
+  `.github/workflows/run_test.yaml`) in addition to SQLite.
+- `pydal/compilers/postgres.py` adds `PostgresCompiler`, overriding
+  `_render_like_left` to cast non-text operands to `::text` — Postgres
+  has no implicit `integer → text` coercion for the `~~` (LIKE)
+  operator, so `field.like(...)` on an integer column needs the cast.
+  The legacy `PostgresDialect.like` got the same `::text` fix (the old
+  `CAST(x AS CHAR(n))` form was broken).
+- `SQLCompiler._render_like_left` hook extracted in the base so the
+  Postgres override is a one-liner.
+
 ---
 
 ## Remaining corners (low-priority)
 
 These are real but cheap-to-leave-alone:
 
-- **Tests against another backend.** Everything is verified on SQLite.
-  The dialect-swap from layer 1 works in principle; running the suite
-  against Postgres / MySQL would confirm and catch any bit-rotted
-  dialect-specific behavior (`postgre.py` `regexp` uses `~`, etc.).
+- **Tests against MySQL / other backends.** SQLite and PostgreSQL are
+  both verified (PostgreSQL runs in CI). Running the suite against
+  MySQL would confirm the remaining dialect-specific behavior and catch
+  any bit-rotted overrides.
 - **Retire the legacy `_select_wcols` body.** Now that the AST path
   covers every shape exercised by the test suite, the 200-line legacy
   block in `adapters/base.py::_select_wcols` could shrink to just the

--- a/TODO.md
+++ b/TODO.md
@@ -44,6 +44,17 @@ what (small) corners remain.
   legacy `Select` bridging.
 - `set.subselect(..., correlated=False)` works directly now.
 
+### 5. MSSQL `limitby` — done
+
+- `SQLCompiler._emit_limitby(n, dst)` hook added; default emits ANSI
+  `LIMIT`/`OFFSET`.
+- `pydal/compilers/mssql.py` adds `MSSQLCompiler` (`mssql`, `mssqln`),
+  `MSSQL3Compiler` (`mssql3`, `mssql3n`) and `MSSQL4Compiler`
+  (`mssql4`, `mssql4n`), each overriding `_emit_limitby` to emit
+  `TOP` / `OFFSET … FETCH NEXT` as appropriate.
+- Removes the `self.compiler = None` workaround that previously forced
+  all MSSQL queries through the legacy dialect path.
+
 ---
 
 ## Remaining corners (low-priority)
@@ -53,8 +64,7 @@ These are real but cheap-to-leave-alone:
 - **Tests against another backend.** Everything is verified on SQLite.
   The dialect-swap from layer 1 works in principle; running the suite
   against Postgres / MySQL would confirm and catch any bit-rotted
-  dialect-specific behavior (`postgre.py` `regexp` uses `~`, MSSQL's
-  `limitby` rewrite, etc.).
+  dialect-specific behavior (`postgre.py` `regexp` uses `~`, etc.).
 - **Retire the legacy `_select_wcols` body.** Now that the AST path
   covers every shape exercised by the test suite, the 200-line legacy
   block in `adapters/base.py::_select_wcols` could shrink to just the

--- a/pydal/ast.py
+++ b/pydal/ast.py
@@ -320,6 +320,10 @@ class Update(Node):
     sets: Tuple[Tuple[str, Node], ...]
     where: Optional[Node] = None
     sqlsafe: Optional[str] = None
+    # The table's ``sql_shortref`` (alias name when aliased, else rname).
+    # Used by backends whose aliased UPDATE/DELETE name the alias in the
+    # leading clause and the full ref in a trailing FROM (e.g. MSSQL).
+    sqlshortref: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -329,6 +333,7 @@ class Delete(Node):
     table: str
     where: Optional[Node] = None
     sqlsafe: Optional[str] = None
+    sqlshortref: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/pydal/ast_translate.py
+++ b/pydal/ast_translate.py
@@ -574,6 +574,7 @@ def set_to_update(s, op_values: Sequence) -> ast.Update:
         sets=sets,
         where=to_ast(query) if query else None,
         sqlsafe=sqlsafe,
+        sqlshortref=table.sql_shortref,
     )
 
 
@@ -595,6 +596,7 @@ def set_to_delete(s) -> ast.Delete:
         table=table._dalname,
         where=to_ast(query) if query else None,
         sqlsafe=sqlsafe,
+        sqlshortref=table.sql_shortref,
     )
 
 

--- a/pydal/backends/postgres.py
+++ b/pydal/backends/postgres.py
@@ -424,9 +424,7 @@ class PostgresDialect(SQLDialect):
                 second = second.replace(escape, escape * 2)
         if first.type not in ("string", "text", "json", "jsonb"):
             return "(%s LIKE %s ESCAPE '%s')" % (
-                self.cast(
-                    self.expand(first, query_env=query_env), "CHAR(%s)" % first.length
-                ),
+                self.expand(first, query_env=query_env) + "::text",
                 second,
                 escape,
             )

--- a/pydal/compilers/__init__.py
+++ b/pydal/compilers/__init__.py
@@ -24,5 +24,6 @@ compilers: Dispatcher = Dispatcher("compiler")
 # side-effects so the registry is populated.
 from .sql import SQLCompiler       # noqa: E402, F401  (side-effect import)
 from .sqlite import SQLiteCompiler  # noqa: E402, F401  (side-effect import)
+from .mssql import MSSQLCompiler, MSSQL3Compiler, MSSQL4Compiler  # noqa: E402, F401
 
-__all__ = ["SQLCompiler", "SQLiteCompiler", "compilers"]
+__all__ = ["SQLCompiler", "SQLiteCompiler", "MSSQLCompiler", "MSSQL3Compiler", "MSSQL4Compiler", "compilers"]

--- a/pydal/compilers/__init__.py
+++ b/pydal/compilers/__init__.py
@@ -25,5 +25,6 @@ compilers: Dispatcher = Dispatcher("compiler")
 from .sql import SQLCompiler       # noqa: E402, F401  (side-effect import)
 from .sqlite import SQLiteCompiler  # noqa: E402, F401  (side-effect import)
 from .mssql import MSSQLCompiler, MSSQL3Compiler, MSSQL4Compiler  # noqa: E402, F401
+from .postgres import PostgresCompiler  # noqa: E402, F401
 
-__all__ = ["SQLCompiler", "SQLiteCompiler", "MSSQLCompiler", "MSSQL3Compiler", "MSSQL4Compiler", "compilers"]
+__all__ = ["SQLCompiler", "SQLiteCompiler", "MSSQLCompiler", "MSSQL3Compiler", "MSSQL4Compiler", "PostgresCompiler", "compilers"]

--- a/pydal/compilers/mssql.py
+++ b/pydal/compilers/mssql.py
@@ -32,6 +32,13 @@ from .sql import SQLCompiler
 class MSSQLCompiler(SQLCompiler):
     """Base MSSQL compiler: replaces ANSI LIMIT with ``SELECT TOP N``."""
 
+    # MSSQL has no boolean literal; a bare ``0``/``1`` is rejected in a
+    # condition context, so booleans must render as real comparisons.
+    true_exp = "1=1"
+    false_exp = "1=0"
+    true_token = "1"
+    false_token = "0"
+
     def _emit_limitby(self, n, dst):
         if not n.limit:
             return dst, "", ""

--- a/pydal/compilers/mssql.py
+++ b/pydal/compilers/mssql.py
@@ -83,6 +83,16 @@ class MSSQLCompiler(SQLCompiler):
             self.visit(args[2]),
         )
 
+    def _render_like_right(self, r, lowered_left, escape_to_double):
+        """Restore the uppercase national-string prefix that ILIKE
+        lowercasing corrupts: MSSQLN represents strings as ``N'...'`` but
+        ILIKE lowercases the whole literal to ``n'...'``, which T-SQL
+        rejects. No-op for non-N MSSQL (literals start with ``'``)."""
+        rendered = super()._render_like_right(r, lowered_left, escape_to_double)
+        if rendered.startswith("n'"):
+            return "N" + rendered[1:]
+        return rendered
+
 
 @compilers.register_for(MSSQL3)
 @compilers.register_for(MSSQL3N)

--- a/pydal/compilers/mssql.py
+++ b/pydal/compilers/mssql.py
@@ -1,0 +1,80 @@
+"""
+MSSQLCompiler: MSSQL-specific SELECT pagination.
+
+MSSQL does not support ANSI ``LIMIT``/``OFFSET``; it uses ``TOP`` and
+(in newer versions) ``OFFSET ... ROWS FETCH NEXT ... ROWS ONLY``.
+
+Three compilers mirror the three MSSQL dialect tiers:
+
+MSSQLCompiler  (MSSQL, MSSQLN — "mssql", "mssql2", "mssqln")
+    Emits ``SELECT TOP N ...`` for all limitby shapes.  For lmin>0 the
+    ``TOP N`` still fetches up to N rows; the adapter's ``Slicer`` mixin
+    then drops the first ``lmin`` rows in Python (same behaviour as the
+    legacy ``MSSQLDialect.select``).
+
+MSSQL3Compiler  (MSSQL3, MSSQL3N — "mssql3", "mssql3n")
+    ``SELECT TOP N`` when lmin=0; raises ``NotImplementedError`` for
+    lmin>0 so the legacy ``ROW_NUMBER()`` subquery path fires instead.
+
+MSSQL4Compiler  (MSSQL4, MSSQL4N — "mssql4", "mssql4n")
+    ``SELECT TOP N`` when lmin=0;
+    ``OFFSET lmin ROWS FETCH NEXT N ROWS ONLY`` when lmin>0.
+"""
+
+from __future__ import annotations
+
+from ..backends.mssql import MSSQL, MSSQL3, MSSQL3N, MSSQL4, MSSQL4N
+from . import compilers
+from .sql import SQLCompiler
+
+
+@compilers.register_for(MSSQL)
+class MSSQLCompiler(SQLCompiler):
+    """Base MSSQL compiler: replaces ANSI LIMIT with ``SELECT TOP N``."""
+
+    def _emit_limitby(self, n, dst):
+        if not n.limit:
+            return dst, "", ""
+        _lmin, lmax = n.limit
+        # TOP goes inside the SELECT … clause, appended to dst
+        # (which may already contain " DISTINCT").
+        return dst + " TOP %i" % lmax, "", ""
+
+
+@compilers.register_for(MSSQL3)
+@compilers.register_for(MSSQL3N)
+class MSSQL3Compiler(MSSQLCompiler):
+    """
+    MSSQL3: TOP for lmin=0; falls back to the legacy ROW_NUMBER() path
+    for lmin>0 (``NotImplementedError`` triggers the fallback in
+    ``_ast_select_wcols``).
+    """
+
+    def _emit_limitby(self, n, dst):
+        if not n.limit:
+            return dst, "", ""
+        lmin, lmax = n.limit
+        if lmin == 0:
+            return dst + " TOP %i" % lmax, "", ""
+        raise NotImplementedError("MSSQL3 offset pagination uses ROW_NUMBER()")
+
+
+@compilers.register_for(MSSQL4)
+@compilers.register_for(MSSQL4N)
+class MSSQL4Compiler(MSSQL3Compiler):
+    """
+    MSSQL4: TOP for lmin=0; ``OFFSET … FETCH NEXT`` for lmin>0.
+    """
+
+    def _emit_limitby(self, n, dst):
+        if not n.limit:
+            return dst, "", ""
+        lmin, lmax = n.limit
+        if lmin == 0:
+            return dst + " TOP %i" % lmax, "", ""
+        # offset goes after ORDER BY; limit slot stays empty
+        offset = " OFFSET %i ROWS FETCH NEXT %i ROWS ONLY" % (lmin, lmax - lmin)
+        return dst, "", offset
+
+
+__all__ = ["MSSQLCompiler", "MSSQL3Compiler", "MSSQL4Compiler"]

--- a/pydal/compilers/mssql.py
+++ b/pydal/compilers/mssql.py
@@ -93,6 +93,17 @@ class MSSQLCompiler(SQLCompiler):
             return "N" + rendered[1:]
         return rendered
 
+    def _render_update(self, n, table, sets, whr):
+        """MSSQL aliased UPDATE names the alias in the leading clause and
+        the full ref in a trailing FROM: ``UPDATE alias SET ... FROM ref``."""
+        return "UPDATE %s SET %s FROM %s%s;" % (
+            n.sqlshortref or table, sets, table, whr,
+        )
+
+    def _render_delete(self, n, table, whr):
+        """MSSQL aliased DELETE: ``DELETE alias FROM ref WHERE ...``."""
+        return "DELETE %s FROM %s%s;" % (n.sqlshortref or table, table, whr)
+
 
 @compilers.register_for(MSSQL3)
 @compilers.register_for(MSSQL3N)

--- a/pydal/compilers/mssql.py
+++ b/pydal/compilers/mssql.py
@@ -40,6 +40,42 @@ class MSSQLCompiler(SQLCompiler):
         # (which may already contain " DISTINCT").
         return dst + " TOP %i" % lmax, "", ""
 
+    # MSSQL has no EXTRACT/LENGTH; mirror the legacy MSSQLDialect.
+    def fn_extract(self, args, opts):
+        """Render ``DATEPART(<unit>, arg)`` — MSSQL has no ``EXTRACT``."""
+        return "DATEPART(%s,%s)" % (opts.get("unit", ""), self.visit(args[0]))
+
+    def un_epoch(self, x, _):
+        """Render epoch via ``DATEDIFF(second, '1970-01-01 00:00:00', ...)``."""
+        return "DATEDIFF(second, '1970-01-01 00:00:00', %s)" % self.visit(x)
+
+    def un_length(self, x, _):
+        """Render ``LEN(operand)`` — MSSQL spells ``LENGTH`` as ``LEN``."""
+        return "LEN(%s)" % self.visit(x)
+
+    def fn_aggregate(self, args, opts):
+        """Render ``KIND(arg)``, mapping ``LENGTH`` to MSSQL's ``LEN``."""
+        kind = opts.get("kind", "")
+        if kind == "LENGTH":
+            kind = "LEN"
+        return "%s(%s)" % (kind, self.visit(args[0]))
+
+    def op_add(self, l, r, opts):
+        """String concatenation uses ``+`` in MSSQL (numeric stays ``+``)."""
+        return "(%s + %s)" % (self.visit(l), self.visit(r))
+
+    def fn_cast(self, args, _):
+        """MSSQL needs no explicit cast — emit the operand unchanged."""
+        return self.visit(args[0])
+
+    def fn_substring(self, args, _):
+        """Render ``SUBSTRING(field, pos, length)`` (MSSQL spelling)."""
+        return "SUBSTRING(%s,%s,%s)" % (
+            self.visit(args[0]),
+            self.visit(args[1]),
+            self.visit(args[2]),
+        )
+
 
 @compilers.register_for(MSSQL3)
 @compilers.register_for(MSSQL3N)

--- a/pydal/compilers/postgres.py
+++ b/pydal/compilers/postgres.py
@@ -1,0 +1,30 @@
+"""
+PostgresCompiler: Postgres-specific expression compilation.
+
+Overrides LIKE/ILIKE rendering to cast non-text operands to ``::text``
+before comparison, since Postgres has no implicit integer→text coercion
+for the ``~~`` (LIKE) operator.
+"""
+
+from __future__ import annotations
+
+from .. import ast
+from ..backends.postgres import Postgres
+from . import compilers
+from .sql import SQLCompiler
+
+_TEXT_TYPES = frozenset(("string", "text", "json", "jsonb"))
+
+
+@compilers.register_for(Postgres)
+class PostgresCompiler(SQLCompiler):
+    def _render_like_left(self, l: ast.Node, lowered_left: bool) -> str:
+        # For non-text fields (e.g. integer) Postgres rejects bare LIKE;
+        # cast the operand to text first.
+        rendered = self.visit(l)
+        if getattr(l, "type", None) not in _TEXT_TYPES:
+            rendered = "%s::text" % rendered
+        return ("LOWER(%s)" % rendered) if lowered_left else rendered
+
+
+__all__ = ["PostgresCompiler"]

--- a/pydal/compilers/sql.py
+++ b/pydal/compilers/sql.py
@@ -802,17 +802,12 @@ class SQLCompiler:
         or a non-Literal expression (rendered as-is). For ILIKE we also
         lowercase the rendered second string and wrap the first in LOWER.
         """
-        if isinstance(r, ast.Literal):
-            rendered = self._represent(r.value, r.type or "string")
-            if lowered_left:
-                rendered = str(rendered).lower()
-            if escape is None:
-                escape = "\\"
-                rendered = str(rendered).replace(escape, escape * 2)
-        else:
-            rendered = self.visit(r)
-            if escape is None:
-                escape = "\\"
+        # When no explicit escape char is given, default to backslash and
+        # (for literals) double any backslash in the pattern itself.
+        double = escape is None
+        if escape is None:
+            escape = "\\"
+        rendered = self._render_like_right(r, lowered_left, escape if double else None)
         left = self._render_like_left(l, lowered_left)
         return "(%s LIKE %s ESCAPE '%s')" % (left, rendered, escape)
 
@@ -821,6 +816,23 @@ class SQLCompiler:
         inject backend-specific casts (e.g. Postgres ``::text``)."""
         rendered = self.visit(l)
         return ("LOWER(%s)" % rendered) if lowered_left else rendered
+
+    def _render_like_right(self, r: ast.Node, lowered_left: bool, escape_to_double):
+        """Render the right-hand operand (pattern) of a LIKE. Subclasses
+        override to fix up backend-specific quirks (e.g. MSSQL restores the
+        uppercase ``N`` prefix that ILIKE lowercasing would corrupt).
+
+        ``escape_to_double`` is the escape char whose occurrences must be
+        doubled in a *literal* pattern (``None`` when an explicit ESCAPE was
+        supplied, so the pattern is taken verbatim)."""
+        if isinstance(r, ast.Literal):
+            rendered = str(self._represent(r.value, r.type or "string"))
+            if lowered_left:
+                rendered = rendered.lower()
+            if escape_to_double is not None:
+                rendered = rendered.replace(escape_to_double, escape_to_double * 2)
+            return rendered
+        return self.visit(r)
 
     def op_like(self, l, r, opts):
         """Render ``(left LIKE right ESCAPE '...')`` — case-sensitive match."""

--- a/pydal/compilers/sql.py
+++ b/pydal/compilers/sql.py
@@ -416,11 +416,16 @@ class SQLCompiler:
                 for col, val in n.sets
             )
             whr = " WHERE %s" % self.visit(n.where) if n.where is not None else ""
-            sql = "UPDATE %s SET %s%s;" % (table, sets, whr)
+            sql = self._render_update(n, table, sets, whr)
         finally:
             self._scope_stack.pop()
             self._ctx = None
         return ParamSQL(sql, ctx.params) if ctx is not None else sql
+
+    def _render_update(self, n: ast.Update, table: str, sets: str, whr: str) -> str:
+        """Assemble the final UPDATE statement. Subclasses override to emit
+        backend-specific shapes (e.g. MSSQL's ``UPDATE alias SET ... FROM table``)."""
+        return "UPDATE %s SET %s%s;" % (table, sets, whr)
 
     def compile_delete(self, n: ast.Delete):
         """Compile a ``Delete`` AST node into ``DELETE FROM ... WHERE ...;`` SQL."""
@@ -429,11 +434,16 @@ class SQLCompiler:
         try:
             table = n.sqlsafe if n.sqlsafe is not None else self._writing_alias(n.table)
             whr = " WHERE %s" % self.visit(n.where) if n.where is not None else ""
-            sql = "DELETE FROM %s%s;" % (table, whr)
+            sql = self._render_delete(n, table, whr)
         finally:
             self._scope_stack.pop()
             self._ctx = None
         return ParamSQL(sql, ctx.params) if ctx is not None else sql
+
+    def _render_delete(self, n: ast.Delete, table: str, whr: str) -> str:
+        """Assemble the final DELETE statement. Subclasses override to emit
+        backend-specific shapes (e.g. MSSQL's ``DELETE alias FROM table``)."""
+        return "DELETE FROM %s%s;" % (table, whr)
 
     def compile_count(self, n: ast.Count):
         """Compile a Count node into ``SELECT COUNT(...) FROM ...;``."""

--- a/pydal/compilers/sql.py
+++ b/pydal/compilers/sql.py
@@ -813,8 +813,14 @@ class SQLCompiler:
             rendered = self.visit(r)
             if escape is None:
                 escape = "\\"
-        left = ("LOWER(%s)" % self.visit(l)) if lowered_left else self.visit(l)
+        left = self._render_like_left(l, lowered_left)
         return "(%s LIKE %s ESCAPE '%s')" % (left, rendered, escape)
+
+    def _render_like_left(self, l: ast.Node, lowered_left: bool) -> str:
+        """Render the left-hand operand of a LIKE. Subclasses override to
+        inject backend-specific casts (e.g. Postgres ``::text``)."""
+        rendered = self.visit(l)
+        return ("LOWER(%s)" % rendered) if lowered_left else rendered
 
     def op_like(self, l, r, opts):
         """Render ``(left LIKE right ESCAPE '...')`` — case-sensitive match."""

--- a/pydal/compilers/sql.py
+++ b/pydal/compilers/sql.py
@@ -209,6 +209,21 @@ class SQLCompiler:
             self._ctx = None
         return ParamSQL(sql, ctx.params) if ctx is not None else sql
 
+    def _emit_limitby(self, n: ast.Select, dst: str):
+        """Return ``(dst, limit_clause, offset_clause)`` for the limit/offset part.
+
+        The default emits ANSI ``LIMIT N OFFSET M``. Subclasses override
+        this to emit backend-specific syntax (e.g. ``SELECT TOP N`` for MSSQL)
+        by modifying ``dst`` and/or returning non-empty limit/offset strings.
+        Raise ``NotImplementedError`` to fall back to the legacy dialect path.
+        """
+        limit = offset = ""
+        if n.limit:
+            lmin, lmax = n.limit
+            limit = " LIMIT %i" % (lmax - lmin)
+            offset = " OFFSET %i" % lmin
+        return dst, limit, offset
+
     def _compile_select_body(self, n: ast.Select) -> str:
         # IMPORTANT: visits happen in SQL-position order. Positional ``?``
         # placeholders bind to params in the order they appear in the
@@ -299,12 +314,9 @@ class SQLCompiler:
             order = ""
             if n.orderby:
                 order = " ORDER BY %s" % ", ".join(self.visit(o) for o in n.orderby)
-            # LIMIT / OFFSET (always inline)
-            limit = offset = ""
-            if n.limit:
-                lmin, lmax = n.limit
-                limit = " LIMIT %i" % (lmax - lmin)
-                offset = " OFFSET %i" % lmin
+            # LIMIT / OFFSET — delegated to _emit_limitby so subclasses
+            # (e.g. MSSQLCompiler) can replace ANSI LIMIT with TOP/FETCH.
+            dst, limit, offset = self._emit_limitby(n, dst)
             # FOR UPDATE
             upd = " FOR UPDATE" if n.for_update else ""
             return "%sSELECT%s %s FROM %s%s%s%s%s%s%s%s;" % (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ ignore = ["E711", "E712"]
 [project.optional-dependencies]
 test = [
     "legacy-cgi; python_version >= '3.13'",
+    "psycopg2-binary",
 ]
 manage = [
     "twine",

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,4 +1,5 @@
 from pydal import DAL
+from pydal.backend_base import BaseAdapter
 
 from ._adapt import DEFAULT_URI, drop
 from ._compat import unittest
@@ -25,3 +26,6 @@ class DALtest(unittest.TestCase):
                 drop(db[table])
             db.close()
         self._connections = []
+        # Reset the thread-local folder so a failed test with folder= set
+        # cannot contaminate subsequent tests.
+        BaseAdapter.set_folder("")

--- a/tests/scheduler.py
+++ b/tests/scheduler.py
@@ -9,12 +9,19 @@ import tempfile
 import time
 
 from pydal import DAL
+from pydal.backend_base import BaseAdapter
 from pydal.tools.scheduler import Scheduler, delta, now
 
 from ._compat import unittest
 
 
 class TestScheduler(unittest.TestCase):
+    def tearDown(self):
+        # The test creates a DAL with folder= a tempdir that is then
+        # deleted; reset the thread-local folder so it cannot poison
+        # subsequent tests.
+        BaseAdapter.set_folder("")
+
     @unittest.skipIf(sys.platform == "win32", "signal.SIGCHLD is not available on Windows")
     def test_scheduler(self):
         completed_tasks = []
@@ -63,3 +70,4 @@ class TestScheduler(unittest.TestCase):
             self.assertEqual(db(db.task_run.status == "failed").count(), 1)
             # for run in db(db.task_run).select():
             #     print(run.name, run.status, run.log)
+            db.close()

--- a/tests/scheduler.py
+++ b/tests/scheduler.py
@@ -4,6 +4,7 @@
 """Unit tests for scheduler.py"""
 
 import datetime
+import sys
 import tempfile
 import time
 
@@ -14,6 +15,7 @@ from ._compat import unittest
 
 
 class TestScheduler(unittest.TestCase):
+    @unittest.skipIf(sys.platform == "win32", "signal.SIGCHLD is not available on Windows")
     def test_scheduler(self):
         completed_tasks = []
 

--- a/tests/validation.py
+++ b/tests/validation.py
@@ -5,8 +5,9 @@ import tempfile
 from pydal import DAL, Field
 # integer_types removed; use int
 
-from ._adapt import DEFAULT_URI, IS_IMAP, IS_NOSQL, drop
+from ._adapt import IS_IMAP, IS_NOSQL
 from ._compat import unittest
+from ._helpers import DALtest
 
 long = int
 
@@ -47,9 +48,9 @@ class IS_INT_IN_RANGE(object):
 
 
 @unittest.skipIf(IS_IMAP, "TODO: IMAP test")
-class TestValidateAndInsert(unittest.TestCase):
+class TestValidateAndInsert(DALtest):
     def testRun(self):
-        db = DAL(DEFAULT_URI, check_reserved=["all"])
+        db = self.connect()
         db.define_table(
             "val_and_insert",
             Field("aa"),
@@ -71,11 +72,9 @@ class TestValidateAndInsert(unittest.TestCase):
         self.assertEqual(rtn.get("id"), None)
         # an error message should be in rtn.errors.bb
         self.assertNotEqual(rtn["errors"]["bb"], None)
-        # cleanup table
-        drop(db.val_and_insert)
 
     def testApiUpload(self):
-        db = DAL(DEFAULT_URI, check_reserved=["all"])
+        db = self.connect()
         with tempfile.TemporaryDirectory() as tempdir:
             db.define_table(
                 "thing",
@@ -106,9 +105,9 @@ class TestValidateAndInsert(unittest.TestCase):
 
 
 @unittest.skipIf(IS_IMAP, "TODO: IMAP test")
-class TestValidateUpdateInsert(unittest.TestCase):
+class TestValidateUpdateInsert(DALtest):
     def testRun(self):
-        db = DAL(DEFAULT_URI, check_reserved=["all"])
+        db = self.connect()
         t1 = db.define_table(
             "t1", Field("int_level", "integer", requires=IS_INT_IN_RANGE(1, 5))
         )
@@ -123,5 +122,3 @@ class TestValidateUpdateInsert(unittest.TestCase):
         self.assertEqual(db(t1.int_level == 1).count(), 0)
         self.assertEqual(db(t1.int_level == 6).count(), 0)
         self.assertEqual(db(t1.int_level == 2).count(), 1)
-        drop(db.t1)
-        return


### PR DESCRIPTION
I noticed my other PR #771 was not passing the tests in appveyor, due to MSSQL problems.

This PR fixes the tests problems with MSSQL  (that were not introduced by #771).

Since I was messing with the tests I also added Postgres to the testing suite, as I'm using it and it was also broken when I ran the tests with it locally.

I think the only big one not being tested yet is mysql.